### PR TITLE
Changed syntax of options checking to support change in ruby 1.9

### DIFF
--- a/lib/dogapi/v1/event.rb
+++ b/lib/dogapi/v1/event.rb
@@ -54,13 +54,13 @@ module Dogapi
           :end => stop.to_i
         }
 
-        if options[:priority]:
+        if options[:priority].nil?
           params[:priority] = options[:priority]
         end
-        if options[:sources]:
+        if options[:sources].nil?
           params[:sources] = options[:sources]
         end
-        if options[:tags]:
+        if options[:tags].nil?
           params[:tags] = options[:tags]
         end
 


### PR DESCRIPTION
The dogapi gem will install on ruby 1.9, but using the functions of the v1 API calls (in my case, event.rb) spits out a few ugly errors:

```
SyntaxError: /usr/local/lib/ruby/gems/1.9.1/gems/dogapi-1.2.3/lib/dogapi/v1/event.rb:57: syntax error, unexpected ':', expecting keyword_then or ';' or '\n'
/usr/local/lib/ruby/gems/1.9.1/gems/dogapi-1.2.3/lib/dogapi/v1/event.rb:60: syntax error, unexpected ':', expecting keyword_then or ';' or '\n'
/usr/local/lib/ruby/gems/1.9.1/gems/dogapi-1.2.3/lib/dogapi/v1/event.rb:63: syntax error, unexpected ':', expecting keyword_then or ';' or '\n'
/usr/local/lib/ruby/gems/1.9.1/gems/dogapi-1.2.3/lib/dogapi/v1/event.rb:70: syntax error, unexpected keyword_end, expecting $end
```

Using the colon for logical statements (if, case) has been removed from ruby 1.9.
