### PR TITLE
fix the event to_hash but i am not sure this is ideal

### DIFF
--- a/lib/dogapi/event.rb
+++ b/lib/dogapi/event.rb
@@ -52,9 +52,9 @@ module Dogapi
     # Copy and pasted from the internets 
     # http://stackoverflow.com/a/5031637/25276
     def to_hash
-      Hash[instance_variables.map { |var| 
-        [var[1..-1].to_sym, instance_variable_get(var)] 
-      }]
+        hash = {}
+        instance_variables.each {|var| hash[var[1..-1].to_sym] = instance_variable_get(var) }
+        hash
     end
   end
 


### PR DESCRIPTION
the map way was giving me this error

<pre>
/usr/lib/ruby/gems/1.8/gems/dogapi-1.3.2/lib/dogapi/event.rb:55:in `[]': odd number of arguments for Hash (ArgumentError)
        from /usr/lib/ruby/gems/1.8/gems/dogapi-1.3.2/lib/dogapi/event.rb:55:in `to_hash'
        from /usr/lib/ruby/gems/1.8/gems/dogapi-1.3.2/lib/dogapi/v1/event.rb:18:in `post'
        from /usr/lib/ruby/gems/1.8/gems/dogapi-1.3.2/lib/dogapi/facade.rb:98:in `emit_event'
</pre>
