### PR TITLE
Handle capistrano 'roles' that are a singular value.

### DIFF
--- a/lib/capistrano/datadog.rb
+++ b/lib/capistrano/datadog.rb
@@ -86,7 +86,7 @@ module Capistrano
         # Convert the tasks into Datadog events
         @tasks.map do |task|
           name  = task[:name]
-          roles = (task[:roles] || []).sort
+          roles = Array(task[:roles]).sort
           tags  = ["#capistrano"] + (roles.map { |t| '#role:' + t })
           title = "%s@%s ran %s on %s with capistrano in %.2f secs" % [user, hostname, name, roles.join(', '), task[:timing]]
           type  = "deploy"


### PR DESCRIPTION
Valid values for :roles on a capistrano task are a list of roles, a
single role or a lambda (which returns one of the two former values).
This ensures that any singular role is an Array for the report.

See issue #12
