### PR TITLE
Translating roles into strings for report.

### DIFF
--- a/lib/capistrano/datadog.rb
+++ b/lib/capistrano/datadog.rb
@@ -90,7 +90,7 @@ module Capistrano
         # Convert the tasks into Datadog events
         @tasks.map do |task|
           name  = task[:name]
-          roles = Array(task[:roles]).sort
+          roles = Array(task[:roles]).map(&:to_s).sort
           tags  = ["#capistrano"] + (roles.map { |t| '#role:' + t })
           title = "%s@%s ran %s on %s with capistrano in %.2f secs" % [user, hostname, name, roles.join(', '), task[:timing]]
           type  = "deploy"


### PR DESCRIPTION
A symbol doesn't coerce into a string, so we have to explicitly do this.

Note, I don't have a great way to test this.  Please review.
