### PR TITLE
Report the application name as well when deploying with Capistrano

### DIFF
--- a/lib/capistrano/datadog.rb
+++ b/lib/capistrano/datadog.rb
@@ -49,12 +49,13 @@ module Capistrano
         @logging_output = {}
       end
 
-      def record_task(task_name, timing, roles, stage=nil)
+      def record_task(task_name, timing, roles, stage=nil, application_name=nil)
         @tasks << {
           :name   => task_name,
           :timing => timing,
           :roles  => roles,
-          :stage  => stage
+          :stage  => stage,
+          :application => application_name
         }
       end
 
@@ -80,7 +81,11 @@ module Capistrano
           if !task[:stage].nil? and !task[:stage].empty? then
             tags << "#stage:#{task[:stage]}"
           end
-          title = "%s@%s ran %s on %s with capistrano in %.2f secs" % [user, hostname, name, roles.join(', '), task[:timing]]
+          application = ''
+          if !task[:application].nil? and !task[:application].empty? then
+            application = ' for ' + task[:application]
+          end
+          title = "%s@%s ran %s%s on %s with capistrano in %.2f secs" % [user, hostname, name, application, roles.join(', '), task[:timing]]
           type  = "deploy"
           alert_type = "success"
           source_type = "capistrano"

--- a/lib/capistrano/datadog/v2.rb
+++ b/lib/capistrano/datadog/v2.rb
@@ -32,7 +32,7 @@ module Capistrano
         if roles.is_a? Proc
           roles = roles.call
         end
-        reporter.record_task(task_name, timing.real, roles, task.namespace.variables[:stage])
+        reporter.record_task(task_name, timing.real, roles, task.namespace.variables[:stage], fetch(:application))
 
         # Return the original result
         result

--- a/lib/capistrano/datadog/v3.rb
+++ b/lib/capistrano/datadog/v3.rb
@@ -15,7 +15,7 @@ module Rake
         result = old_invoke(*args)
       end
       reporter.record_task(task_name, timing.real, roles,
-        Capistrano::Configuration.env.fetch(:stage))
+        Capistrano::Configuration.env.fetch(:stage), Capistrano::Configuration.env.fetch(:application))
       result
     end
   end


### PR DESCRIPTION
If an application name is set, this will add that to the message
supplied to Datadag. This is especially useful when you have multiple
applications.
