### PR TITLE
Encode capistrano output messages to UTF-8 before manipulating them.

### DIFF
--- a/lib/capistrano/datadog.rb
+++ b/lib/capistrano/datadog.rb
@@ -92,7 +92,7 @@ module Capistrano
           message_content = (@logging_output[name] || []).join('')
           message = if !message_content.empty? then
             # Strip out color control characters
-            message_content = message_content.gsub(/\e\[(\d+)m/, '')
+            message_content = sanitize_encoding(message_content).gsub(/\e\[(\d+)m/, '')
             "@@@\n#{message_content}@@@" else "" end
 
           Dogapi::Event.new(message,
@@ -104,6 +104,11 @@ module Capistrano
             :tags             => tags
           )
         end
+      end
+
+      def sanitize_encoding(string)
+        return string unless defined?(::Encoding) && string.encoding == Encoding::BINARY
+        string.encode(Encoding::UTF_8, Encoding::BINARY, invalid: :replace, undef: :replace, replace: '')
       end
     end
 


### PR DESCRIPTION
Hi, we had encoding issues with the datadog capistrano plugin:

```
Could not submit to Datadog: #<ArgumentError: invalid byte sequence in US-ASCII>
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog.rb:90:in `gsub'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog.rb:90:in `block in report'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog.rb:76:in `map'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog.rb:76:in `report'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog.rb:29:in `submit'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog/v2.rb:69:in `block (3 levels) in <module:Datadog>'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/bundler/gems/capistrano-recipes-328e2cdeb41d/lib/capistrano_recipes/task_timer.rb:26:in `block in execute_task_with_benchmarking'
/usr/lib/shopify-ruby/2.1.0-github/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/bundler/gems/capistrano-recipes-328e2cdeb41d/lib/capistrano_recipes/task_timer.rb:25:in `execute_task_with_benchmarking'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog/v2.rb:25:in `block in find_and_execute_task'
/usr/lib/shopify-ruby/2.1.0-github/lib/ruby/2.1.0/benchmark.rb:279:in `measure'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/dogapi-1.9.2/lib/capistrano/datadog/v2.rb:20:in `find_and_execute_task'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/callback.rb:38:in `call'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:141:in `block in trigger'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:141:in `each'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/configuration/callbacks.rb:141:in `trigger'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:35:in `execute!'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/lib/capistrano/cli/execute.rb:14:in `execute'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/gems/capistrano-2.15.5/bin/cap:4:in `<top (required)>'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/bin/cap:23:in `load'
/u/apps/shipit/releases/20141023173416/data/bundler/ruby/2.1.0/bin/cap:23:in `<main
```

This patch does fix it for us.

Regards. 
