### PR TITLE
add open_timeout to avoid stuck

### DIFF
--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -92,6 +92,7 @@ module Dogapi
 
       uri = URI.parse(@api_host)
       session = connection.new(uri.host, uri.port)
+      session.open_timeout = @timeout
       session.use_ssl = uri.scheme == 'https'
       session.start do |conn|
         conn.read_timeout = @timeout


### PR DESCRIPTION
Hi:

We found sometime all our threads were blocked while doing emit_points. while the call stack looks like:

```
 ["/var/vcap/packages/ruby/lib/ruby/2.1.0/net/http.rb:879:in `initialize'",
  "/var/vcap/packages/ruby/lib/ruby/2.1.0/net/http.rb:879:in `open'",
  "/var/vcap/packages/ruby/lib/ruby/2.1.0/net/http.rb:879:in `block in connect'",
  "/var/vcap/packages/ruby/lib/ruby/2.1.0/timeout.rb:76:in `timeout'",
  "/var/vcap/packages/ruby/lib/ruby/2.1.0/net/http.rb:878:in `connect'",
  "/var/vcap/packages/ruby/lib/ruby/2.1.0/net/http.rb:863:in `do_start'",
  "/var/vcap/packages/ruby/lib/ruby/2.1.0/net/http.rb:852:in `start'",
  "/var/vcap/packages/health_monitor/gem_home/ruby/2.1.0/gems/dogapi-1.6.0/lib/dogapi/common.rb:94:in `connect'",
  "/var/vcap/packages/health_monitor/gem_home/ruby/2.1.0/gems/dogapi-1.6.0/lib/dogapi/common.rb:117:in `request'",
  "/var/vcap/packages/health_monitor/gem_home/ruby/2.1.0/gems/dogapi-1.6.0/lib/dogapi/v1/metric.rb:40:in `submit'",
  "/var/vcap/packages/health_monitor/gem_home/ruby/2.1.0/gems/dogapi-1.6.0/lib/dogapi/facade.rb:85:in `emit_points'",
...
]
```

After checking the code and it seems the open_timeout is default to nil so open timeout exception will not be triggered.
want to add a open_timeout as we do for read_timeout to avoid thread blocks.

PR as follows.

Thanks.
