### PR TITLE
`Dogapi::Client#batch_metrics` should return response from API

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -94,7 +94,7 @@ module Dogapi
       @metric_svc.switch_to_batched
       begin
         yield
-        @metric_svc.flush_buffer
+        @metric_svc.flush_buffer # flush_buffer should returns the response from last API call
       ensure
         @metric_svc.switch_to_single
       end

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -38,8 +38,9 @@ module Dogapi
       end
 
       def flush_buffer()
-        self.upload(@buffer)
+        payload = @buffer
         @buffer = nil
+        self.upload(payload)
       end
 
       alias :submit :submit_to_api

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -35,6 +35,7 @@ module Dogapi
       def submit_to_buffer(metric, points, scope, options = {})
         payload = self.make_metric_payload(metric, points, scope, options)
         @buffer << payload
+        return 200, {}
       end
 
       def flush_buffer()

--- a/spec/facade_spec.rb
+++ b/spec/facade_spec.rb
@@ -17,6 +17,7 @@ describe "Facade", :vcr => true do
       @service.instance_variable_set(:@uploaded, Array.new)
       def @service.upload payload
         @uploaded << payload
+        return 200, {}
       end
     end
 
@@ -49,10 +50,11 @@ describe "Facade", :vcr => true do
     end
 
     it "emit_points can be batched" do
-      @dogmock.batch_metrics do
+      code, resp = @dogmock.batch_metrics do
         @dogmock.emit_point("metric.name", 1, :type => 'counter')
         @dogmock.emit_point("othermetric.name", 2, :type => 'counter')
       end
+      expect(code).to eq 200
       # Verify that we uploaded what we expected
       uploaded =  @service.instance_variable_get(:@uploaded)
       expect(uploaded.length).to eq 1


### PR DESCRIPTION
I think `dogapi` should not just discard the response from API. 