### PR TITLE
Use MultiJSON

### DIFF
--- a/dogapi.gemspec
+++ b/dogapi.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
                     '--main' << 'README.rdoc' <<
                     '--line-numbers' << '--inline-source'
 
-  spec.add_dependency 'json', '>= 1.5.1'
+  spec.add_dependency 'multi_json'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10'

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -5,7 +5,7 @@ require 'socket'
 require 'uri'
 
 require 'rubygems'
-require 'json'
+require 'multi_json'
 
 module Dogapi
 
@@ -52,7 +52,7 @@ module Dogapi
         req.set_form_data params
         resp = conn.request(req)
         begin
-          resp_obj = JSON.parse(resp.body)
+          resp_obj = MultiJson.load(resp.body)
         rescue
           raise 'Invalid JSON Response: ' + resp.body
         end
@@ -128,7 +128,7 @@ module Dogapi
 
         if send_json
           req.content_type = 'application/json'
-          req.body = JSON.generate(body)
+          req.body = MultiJson.dump(body)
         end
 
         resp = conn.request(req)
@@ -136,7 +136,7 @@ module Dogapi
 
         if resp.code != 204 and resp.body != '' and resp.body != 'null' and resp.body != nil
           begin
-            resp_obj = JSON.parse(resp.body)
+            resp_obj = MultiJson.load(resp.body)
           rescue
             raise 'Invalid JSON Response: ' + resp.body
           end

--- a/lib/dogapi/event.rb
+++ b/lib/dogapi/event.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 
 require 'rubygems'
-require 'json'
+require 'multi_json'
 
 module Dogapi
 

--- a/lib/dogapi/metric.rb
+++ b/lib/dogapi/metric.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 
 require 'rubygems'
-require 'json'
+require 'multi_json'
 
 module Dogapi
 


### PR DESCRIPTION
In this fix, remove the dependency on json library, and modified to use [multi_json](https://github.com/intridea/multi_json).

json is already included in the standard library of Ruby 1.9.
Installation of dogapi requires an extra package if `add_dependency ’json’` is written. 
(e.g. gcc, make, ruby-devel...)

