### PR TITLE
v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changes
 =======
 
+# 1.20.0 / Unreleased
+* [FEATURE] Embeddable graphs API. See [#73][]
+
 # 1.19.0 / 2015-06-22
 * [FEATURE] Revoke a shared a Screenboard. See [#69][]
 
@@ -130,6 +133,7 @@ Changes
 [#62]: https://github.com/DataDog/dogapi-rb/issues/62
 [#64]: https://github.com/DataDog/dogapi-rb/issues/64
 [#69]: https://github.com/DataDog/dogapi-rb/issues/69
+[#73]: https://github.com/DataDog/dogapi-rb/issues/73
 [@ArjenSchwarz]: https://github.com/ArjenSchwarz
 [@Kaixiang]: https://github.com/Kaixiang
 [@ansel1]: https://github.com/ansel1

--- a/lib/dogapi/version.rb
+++ b/lib/dogapi/version.rb
@@ -1,3 +1,3 @@
 module Dogapi
-  VERSION = "1.19.0"
+  VERSION = "1.20.0"
 end


### PR DESCRIPTION
* [FEATURE] Embeddable graphs API. See [#73][]

[#73]: https://github.com/DataDog/dogapi-rb/issues/73
[skip ci]