### PR TITLE
Switch to if/else instead of alias method

### DIFF
--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -44,16 +44,20 @@ module Dogapi
         self.upload(payload)
       end
 
-      alias :submit :submit_to_api
+      def submit(*args)
+        if @buffer
+          submit_to_buffer(*args)
+        else
+          submit_to_api(*args)
+        end
+      end
 
       def switch_to_batched()
-        alias :submit :submit_to_buffer
         @buffer = Array.new
       end
 
       def switch_to_single()
         @buffer = nil
-        alias :submit :submit_to_api
       end
 
       def make_metric_payload(metric, points, scope, options)


### PR DESCRIPTION
Aliasing dynamically at runtime surprised me when reading the code and I expect it will surprise others. I replaced it with a simpler if/else statement to remove the surprise factor. 

This should also speed things up a (very) tiny bit, since the method cache for the class will no longer be busted each time.