### PR TITLE
[metric] support for metric query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 Gemfile.lock
 doc/
 pkg/
+.idea

--- a/README.rdoc
+++ b/README.rdoc
@@ -119,3 +119,25 @@ data point you will need to pass a list of +Time+, +float+ pairs, instead of a s
     dog = Dogapi::Client.new(api_key)
 
     dog.emit_points('some.metric.name', [[t1, val1], [t2, val2], [t3, val3]], :host => "my_host", :device => "my_device")
+
+
+== Get points from a Datadog metric
+
+    require 'rubygems'
+    require 'dogapi'
+
+    api_key = "abcd123"
+    application_key = "brec1252"
+
+    dog = Dogapi::Client.new(api_key, application_key)
+
+    # get points from the last hour
+    from = Time.now - 3600
+    to = Time.now
+
+    query = 'sum:metric.count{*}.as_count()'
+
+    dog.get_points(from, to, query)
+
+
+

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -97,8 +97,8 @@ module Dogapi
     # +to+ The seconds since the unix epoch <tt>[Time, Integer]</tt>
     # +query+ The query string <tt>[String]</tt>
     #
-    def get_points(from, to, query)
-      @metric_svc.get(from, to, query)
+    def get_points(query, from, to)
+      @metric_svc.get(query, from, to)
     end
 
     def batch_metrics()

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -91,6 +91,16 @@ module Dogapi
       @metric_svc.submit(metric, points, scope, options)
     end
 
+    # Get a set of points by query between from and to
+    #
+    # +from+ The seconds since the unix epoch <tt>[Time, Integer]</tt>
+    # +to+ The seconds since the unix epoch <tt>[Time, Integer]</tt>
+    # +query+ The query string <tt>[String]</tt>
+    #
+    def get_points(from, to, query)
+      @metric_svc.get(from, to, query)
+    end
+
     def batch_metrics()
       @metric_svc.switch_to_batched
       begin

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -8,6 +8,27 @@ module Dogapi
 
       API_VERSION = "v1"
 
+      def get(from, to, query)
+        begin
+          params = {
+              :api_key => @api_key,
+              :application_key => @application_key,
+
+              from: from.to_i,
+              to: to.to_i,
+              query: query
+          }
+          request(Net::HTTP::Get, '/api/' + API_VERSION + '/query', params, nil, false)
+        rescue Exception => e
+          if @silent
+            warn e
+            return -1, {}
+          else
+            raise e
+          end
+        end
+      end
+
       def upload(metrics)
         begin
           params = {

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -8,15 +8,15 @@ module Dogapi
 
       API_VERSION = "v1"
 
-      def get(from, to, query)
+      def get(query, from, to)
         begin
           params = {
-              :api_key => @api_key,
-              :application_key => @application_key,
+            :api_key => @api_key,
+            :application_key => @application_key,
 
-              from: from.to_i,
-              to: to.to_i,
-              query: query
+            from: from.to_i,
+            to: to.to_i,
+            query: query
           }
           request(Net::HTTP::Get, '/api/' + API_VERSION + '/query', params, nil, false)
         rescue Exception => e


### PR DESCRIPTION
Rebase of #88.
**Added**
* Change `dogapi.get_points` method interface, `from, to`↔`query`, i.e.
  
  ```ruby
  def get_points(query, from, to)
    ...
  end
  ```
* Fix tailor style check violations

Thanks again @blakehilscher!