### PR TITLE
[capistrano] add 3.5.0 compatibility

### DIFF
--- a/lib/capistrano/datadog/v3.rb
+++ b/lib/capistrano/datadog/v3.rb
@@ -30,7 +30,12 @@ module Capistrano
       end
 
       def write(*args)
-        @wrapped.write(*args)
+        # Check if Capistrano version >= 3.5.0
+        if Gem::Version.new(VERSION) >= Gem::Version.new('3.5.0')
+          @wrapped << args
+        else
+          @wrapped.write(*args)
+        end
         args.each { |arg| Capistrano::Datadog.reporter.record_log(arg) }
       end
       alias :<< :write


### PR DESCRIPTION
Capistrano 3.5.0 upgraded its `sshkit` library to `1.9.0` (from `1.3`).
Since we we're relying on a monkey patch of it, it broke the integration.

This is the minimal set of change to fix this issue.