### PR TITLE
Fix CaptureIO delegation

### DIFF
--- a/lib/capistrano/datadog/v3.rb
+++ b/lib/capistrano/datadog/v3.rb
@@ -1,4 +1,5 @@
 require 'benchmark'
+require 'delegate'
 require 'sshkit/formatters/pretty'
 require 'sshkit/formatters/simple_text'
 
@@ -24,8 +25,9 @@ end
 
 module Capistrano
   module Datadog
-    class CaptureIO
+    class CaptureIO < SimpleDelegator
       def initialize(wrapped)
+        super
         @wrapped = wrapped
       end
 
@@ -39,10 +41,6 @@ module Capistrano
         args.each { |arg| Capistrano::Datadog.reporter.record_log(arg) }
       end
       alias :<< :write
-
-      def close
-        @wrapped.close
-      end
     end
   end
 end

--- a/lib/capistrano/datadog/v3.rb
+++ b/lib/capistrano/datadog/v3.rb
@@ -34,7 +34,7 @@ module Capistrano
       def write(*args)
         # Check if Capistrano version >= 3.5.0
         if Gem::Version.new(VERSION) >= Gem::Version.new('3.5.0')
-          @wrapped << args
+          @wrapped << args.join
         else
           @wrapped.write(*args)
         end


### PR DESCRIPTION
SSHKit try to call `tty?` on the output instance to know if it can send ANSI color codes.

This PR fix the way `CaptureIO` does delegation, so that SSHKit isn't wrongly told that the output isn't a TTY.

