### PR TITLE
Enable :name option for get_all_monitors

### DIFF
--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -56,6 +56,11 @@ module Dogapi
           extra_params[:tags] = extra_params[:tags].join(',') if extra_params[:tags].respond_to?(:join)
         end
 
+        # :name is a string to filter monitors by name
+        if options[:name]
+          extra_params[:name] = options[:name]
+        end
+
         request(Net::HTTP::Get, "/api/#{API_VERSION}/monitor", extra_params, nil, false)
       end
 

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -35,7 +35,7 @@ describe Dogapi::Client do
   describe '#get_all_monitors' do
     it_behaves_like 'an api method with optional params',
                     :get_all_monitors, [],
-                    :get, '/monitor', group_states: %w(custom all), tags: ['test', 'key:value']
+                    :get, '/monitor', group_states: %w(custom all), tags: ['test', 'key:value'], name: 'test'
   end
 
   describe '#mute_monitors' do


### PR DESCRIPTION
Hi, 

I enabled `:name` option for `get_all_monitors` method.
Because I want to filter monitors by `:name` option.

- http://docs.datadoghq.com/ja/api/?lang=ruby#monitor-get-all

Please confirm.

Regards.

Yohei