### PR TITLE
Add cancel by scope endpoint

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -451,6 +451,10 @@ module Dogapi
       @monitor_svc.cancel_downtime(downtime_id)
     end
 
+    def cancel_downtime_by_scope(scope)
+      @monitor_svc.cancel_downtime_by_scope(scope)
+    end
+
     def get_all_downtimes(options= {})
       @monitor_svc.get_all_downtimes(options)
     end

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -11,7 +11,7 @@ module Dogapi
   # otherwise noted, the response body is deserialized JSON. Up-to-date
   # information about the JSON object structure is available in the HTTP API
   # documentation, here[https://github.com/DataDog/dogapi/wiki].
-  class Client
+  class Client # rubocop:disable Metrics/ClassLength
 
     def initialize(api_key, application_key=nil, host=nil, device=nil, silent=true, timeout=nil, endpoint=nil)
 

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -105,7 +105,7 @@ module Dogapi
       def cancel_downtime(downtime_id)
         request(Net::HTTP::Delete, "/api/#{API_VERSION}/downtime/#{downtime_id}", nil, nil, false)
       end
-      
+
       def cancel_downtime_by_scope(scope)
         body = {
           'scope' => scope

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -105,6 +105,14 @@ module Dogapi
       def cancel_downtime(downtime_id)
         request(Net::HTTP::Delete, "/api/#{API_VERSION}/downtime/#{downtime_id}", nil, nil, false)
       end
+      
+      def cancel_downtime_by_scope(scope)
+        body = {
+          'scope' => scope
+        }
+        
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/downtime/cancel/by_scope", nil, body, false)
+      end
 
       def get_all_downtimes(options = {})
         request(Net::HTTP::Get, "/api/#{API_VERSION}/downtime", options, nil, false)

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -107,11 +107,7 @@ module Dogapi
       end
 
       def cancel_downtime_by_scope(scope)
-        body = {
-          'scope' => scope
-        }
-        
-        request(Net::HTTP::Post, "/api/#{API_VERSION}/downtime/cancel/by_scope", nil, body, false)
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/downtime/cancel/by_scope", nil, { 'scope' => scope }, false)
       end
 
       def get_all_downtimes(options = {})

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -95,7 +95,7 @@ describe Dogapi::Client do
   describe '#cancel_downtime_by_scope' do
     it_behaves_like 'an api method',
                     :cancel_downtime_by_scope, [DOWNTIME_SCOPE],
-                    :post, '/downtime/cancel/by_scope', 'scope' => DOWNTIME_SCOPE
+                    :post, '/downtime/cancel/by_scope'
   end
 
   describe '#get_all_downtimes' do

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -91,7 +91,7 @@ describe Dogapi::Client do
                     :cancel_downtime, [DOWNTIME_ID],
                     :delete, "/downtime/#{DOWNTIME_ID}"
   end
-  
+
   describe '#cancel_downtime_by_scope' do
     it_behaves_like 'an api method',
                     :cancel_downtime_by_scope, [DOWNTIME_SCOPE],

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -93,7 +93,7 @@ describe Dogapi::Client do
   end
   
   describe '#cancel_downtime_by_scope' do
-    it_behaves_like 'an api method',
+    it_behaves_like 'an api method with options',
                     :cancel_downtime_by_scope, [DOWNTIME_SCOPE],
                     :post, "/downtime/cancel/by_scope", 'scope' => DOWNTIME_SCOPE
   end

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -93,7 +93,7 @@ describe Dogapi::Client do
   end
   
   describe '#cancel_downtime_by_scope' do
-    it_behaves_like 'an api method with options',
+    it_behaves_like 'an api method',
                     :cancel_downtime_by_scope, [DOWNTIME_SCOPE],
                     :post, '/downtime/cancel/by_scope', 'scope' => DOWNTIME_SCOPE
   end

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -95,7 +95,7 @@ describe Dogapi::Client do
   describe '#cancel_downtime_by_scope' do
     it_behaves_like 'an api method with options',
                     :cancel_downtime_by_scope, [DOWNTIME_SCOPE],
-                    :post, "/downtime/cancel/by_scope", 'scope' => DOWNTIME_SCOPE
+                    :post, '/downtime/cancel/by_scope', 'scope' => DOWNTIME_SCOPE
   end
 
   describe '#get_all_downtimes' do

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -91,6 +91,12 @@ describe Dogapi::Client do
                     :cancel_downtime, [DOWNTIME_ID],
                     :delete, "/downtime/#{DOWNTIME_ID}"
   end
+  
+  describe '#cancel_downtime_by_scope' do
+    it_behaves_like 'an api method',
+                    :cancel_downtime_by_scope, [DOWNTIME_SCOPE],
+                    :post, "/downtime/cancel/by_scope", 'scope' => DOWNTIME_SCOPE
+  end
 
   describe '#get_all_downtimes' do
     it_behaves_like 'an api method with optional params',


### PR DESCRIPTION
This method is documented at https://docs.datadoghq.com/api/?lang=ruby#cancel-downtime-by-scope so it should be a fairly straightforward addition.