### PR TITLE
Allow all available metric data types

### DIFF
--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -7,6 +7,12 @@ module Dogapi
     class MetricService < Dogapi::APIService
 
       API_VERSION = 'v1'
+      METRIC_TYPES = %w(
+        count
+        counter
+        gauge
+        rate
+      )
 
       def get(query, from, to)
         extra_params = {
@@ -59,16 +65,16 @@ module Dogapi
 
       def make_metric_payload(metric, points, scope, options)
         begin
-          typ = options[:type] || 'gauge'
+          type = options[:type] || 'gauge'
 
-          if typ != 'gauge' && typ != 'counter'
-            raise ArgumentError, 'metric type must be gauge or counter'
+          unless METRIC_TYPES.include?(type)
+            raise ArgumentError, 'metric type is invalid'
           end
 
           metric_payload = {
             :metric => metric,
             :points => points,
-            :type => typ,
+            :type => type,
             :host => scope.host,
             :device => scope.device
           }

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -65,7 +65,7 @@ module Dogapi
 
       def make_metric_payload(metric, points, scope, options)
         begin
-          type = options[:type] || 'gauge'
+          type = options[:type]
 
           unless METRIC_TYPES.include?(type)
             raise ArgumentError, 'metric type is invalid'


### PR DESCRIPTION
I was playing around the gem in order to allow the same metric types as the service.

<img width="203" alt="screen shot 2017-08-31 at 8 11 42 pm" src="https://user-images.githubusercontent.com/207902/29943354-c3b7b18c-8e88-11e7-9771-06844ca4e9f5.png">

This is what it boiled down to:
```
dog = Dogapi::Client.new('token')
response = dog.emit_point('test.type.count', 1, host: "datacat", type: 'count')
puts response.inspect
=> ["202", {"status"=>"ok"}]
```

But the type didn't register properly in the backend:
<img width="408" alt="screen shot 2017-08-31 at 8 16 09 pm" src="https://user-images.githubusercontent.com/207902/29943519-435d857e-8e89-11e7-8950-fa27a43c4ba1.png">

I can only presume the backend issue is why there is a hard limit for these 2 types in the ruby gem for now?
Could you advice on if/how I should pursue resolution of this issue?

Thank you