### PR TITLE
change http-method GET to POST on api.Screenboard#share

### DIFF
--- a/lib/dogapi/v1/screenboard.rb
+++ b/lib/dogapi/v1/screenboard.rb
@@ -28,7 +28,7 @@ module Dogapi
       end
 
       def share_screenboard(board_id)
-        request(Net::HTTP::Get, "/api/#{API_VERSION}/screen/share/#{board_id}", nil, nil, false)
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/screen/share/#{board_id}", nil, nil, false)
       end
 
       def revoke_screenboard(board_id)

--- a/spec/integration/screenboard_spec.rb
+++ b/spec/integration/screenboard_spec.rb
@@ -50,7 +50,7 @@ describe Dogapi::Client do
   describe '#share_screenboard' do
     it_behaves_like 'an api method',
                     :share_screenboard, [BOARD_ID],
-                    :get, "/screen/share/#{BOARD_ID}"
+                    :post, "/screen/share/#{BOARD_ID}"
   end
 
   describe '#revoke_screenboard' do


### PR DESCRIPTION
We changed the Screenboard:share api from GET to POST since https://github.com/DataDog/dogweb/pull/22149