### PR TITLE
[dashboard list] Add new endpoints + spec

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -33,6 +33,9 @@ module Dogapi
       @comment_svc = Dogapi::V1::CommentService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @search_svc = Dogapi::V1::SearchService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @dash_service = Dogapi::V1::DashService.new(@api_key, @application_key, silent, timeout, @datadog_host)
+      @dashboard_list_service = Dogapi::V1::DashboardListService.new(
+        @api_key, @application_key, silent, timeout, @datadog_host
+      )
       @alert_svc = Dogapi::V1::AlertService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @user_svc = Dogapi::V1::UserService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @snapshot_svc = Dogapi::V1::SnapshotService.new(@api_key, @application_key, silent, timeout, @datadog_host)
@@ -269,6 +272,46 @@ module Dogapi
     # Delete the given dashboard.
     def delete_dashboard(dash_id)
       @dash_service.delete_dashboard(dash_id)
+    end
+
+    #
+    # DASHBOARD LISTS
+    #
+
+    def create_dashboard_list(name)
+      @dashboard_list_service.create_dashboard_list(name)
+    end
+
+    def update_dashboard_list(dashboard_list_id, name)
+      @dashboard_list_service.update_dashboard_list(dashboard_list_id, name)
+    end
+
+    def get_dashboard_list(dashboard_list_id)
+      @dashboard_list_service.get_dashboard_list(dashboard_list_id)
+    end
+
+    def get_all_dashboard_lists()
+      @dashboard_list_service.all_dashboard_lists()
+    end
+
+    def delete_dashboard_list(dashboard_list_id)
+      @dashboard_list_service.delete_dashboard_list(dashboard_list_id)
+    end
+
+    def add_dashboards_to_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service.add_dashboards_to_dashboard_list(dashboard_list_id, dashboards)
+    end
+
+    def update_dashboards_of_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service.update_dashboards_of_dashboard_list(dashboard_list_id, dashboards)
+    end
+
+    def delete_dashboards_from_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service.delete_dashboards_from_dashboard_list(dashboard_list_id, dashboards)
+    end
+
+    def get_dashboards_for_dashboard_list(dashboard_list_id)
+      @dashboard_list_service.get_dashboards_for_dashboard_list(dashboard_list_id)
     end
 
     #

--- a/lib/dogapi/v1.rb
+++ b/lib/dogapi/v1.rb
@@ -1,6 +1,7 @@
 require 'dogapi/v1/alert'
 require 'dogapi/v1/comment'
 require 'dogapi/v1/dash'
+require 'dogapi/v1/dashboard_list'
 require 'dogapi/v1/embed'
 require 'dogapi/v1/event'
 require 'dogapi/v1/metadata'

--- a/lib/dogapi/v1/dashboard_list.rb
+++ b/lib/dogapi/v1/dashboard_list.rb
@@ -1,0 +1,94 @@
+require 'dogapi'
+
+module Dogapi
+  class V1 # for namespacing
+
+    # Dashboard List API
+    class DashboardListService < Dogapi::APIService
+
+      API_VERSION = 'v1'
+
+      def create_dashboard_list(name)
+        body = {
+          name: name
+        }
+
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/dashboard/lists/manual", nil, body, true)
+      end
+
+      def update_dashboard_list(dashboard_list_id, name)
+        body = {
+          name: name
+        }
+
+        request(Net::HTTP::Put, "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}", nil, body, true)
+      end
+
+      def get_dashboard_list(dashboard_list_id)
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}", nil, nil, false)
+      end
+
+      def all_dashboard_lists
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/dashboard/lists/manual", nil, nil, false)
+      end
+
+      def delete_dashboard_list(dashboard_list_id)
+        request(Net::HTTP::Delete, "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}", nil, nil, false)
+      end
+
+      def get_dashboards_for_dashboard_list(dashboard_list_id)
+        request(
+          Net::HTTP::Get,
+          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          nil,
+          nil,
+          false
+        )
+      end
+
+      def add_dashboards_to_dashboard_list(dashboard_list_id, dashboards)
+        body = {
+          dashboards: dashboards
+        }
+
+        request(
+          Net::HTTP::Post,
+          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          nil,
+          body,
+          true
+        )
+      end
+
+      def update_dashboards_of_dashboard_list(dashboard_list_id, dashboards)
+        body = {
+          dashboards: dashboards
+        }
+
+        request(
+          Net::HTTP::Put,
+          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          nil,
+          body,
+          true
+        )
+      end
+
+      def delete_dashboards_from_dashboard_list(dashboard_list_id, dashboards)
+        body = {
+          dashboards: dashboards
+        }
+
+        request(
+          Net::HTTP::Delete,
+          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          nil,
+          body,
+          true
+        )
+      end
+
+    end
+
+  end
+end

--- a/spec/integration/dashboard_list_spec.rb
+++ b/spec/integration/dashboard_list_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../spec_helper'
+
+describe Dogapi::Client do
+  DASHBOARD_LIST_ID = 1_234_567
+  DASHBOARD_LIST_NAME = 'My new dashboard list'.freeze
+
+  DASHBOARDS = [
+    {
+      'type' => 'custom_timeboard',
+      'id' => 1234
+    },
+    {
+      'type' => 'custom_screenboard',
+      'id' => 1234
+    }
+  ].freeze
+
+  DASHBOARD_LIST_BODY = {
+    name: DASHBOARD_LIST_NAME
+  }.freeze
+
+  DASHBOARD_LIST_WITH_DASHES_BODY = {
+    dashboards: DASHBOARDS
+  }.freeze
+
+  describe '#create_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :create_dashboard_list, [DASHBOARD_LIST_NAME],
+                    :post, '/dashboard/lists/manual', DASHBOARD_LIST_BODY
+  end
+
+  describe '#update_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :update_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARD_LIST_NAME],
+                    :put, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}", DASHBOARD_LIST_BODY
+  end
+
+  describe '#get_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :get_dashboard_list, [DASHBOARD_LIST_ID],
+                    :get, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}"
+  end
+
+  describe '#get_all_dashboard_lists' do
+    it_behaves_like 'an api method',
+                    :get_all_dashboard_lists, [],
+                    :get, '/dashboard/lists/manual'
+  end
+
+  describe '#delete_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :delete_dashboard_list, [DASHBOARD_LIST_ID],
+                    :delete, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}"
+  end
+
+  describe '#add_dashboards_to_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :add_dashboards_to_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :post, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards", DASHBOARD_LIST_WITH_DASHES_BODY
+  end
+
+  describe '#update_dashboards_of_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :update_dashboards_of_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :put, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards", DASHBOARD_LIST_WITH_DASHES_BODY
+  end
+
+  describe '#delete_dashboards_from_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :delete_dashboards_from_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :delete, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards", DASHBOARD_LIST_WITH_DASHES_BODY
+  end
+
+  describe '#get_dashboards_for_dashboard_list' do
+    it_behaves_like 'an api method',
+                    :get_dashboards_for_dashboard_list, [DASHBOARD_LIST_ID],
+                    :get, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards"
+  end
+end


### PR DESCRIPTION
This PR adds the new API endpoints for managing dashboard lists:

- Get all dashboard lists: `GET dashboard/lists/manual`

- Get dashboard list: `GET dashboard/lists/manual/{dashboard_list_id}`

- Create dashboard list: `POST dashboard/lists/manual`

- Update dashboard list: `PUT dashboard/lists/manual/{dashboard_list_id}`

- Delete dashboard list: `DELETE dashboard/lists/manual/{dashboard_list_id}`

- Get dashboards for dashboard list: `GET dashboard/lists/manual/{dashboard_list_id}/dashboards`

- Add dashboards to dashboard list: `POST dashboard/lists/manual/{dashboard_list_id}/dashboards`

- Update dashboards of dashboard list: `PUT dashboard/lists/manual/{dashboard_list_id}/dashboards`

- Delete dashboards from dashboard list: `DELETE dashboard/lists/manual/{dashboard_list_id}/dashboards`