### PR TITLE
Handle capistrano tasks with missing timing

### DIFF
--- a/lib/capistrano/datadog.rb
+++ b/lib/capistrano/datadog.rb
@@ -94,8 +94,6 @@ module Capistrano
         # Lazy randomness
         aggregation_key = Digest::MD5.hexdigest "#{Time.new}|#{rand}"
 
-        filter = event_filter || proc { |x| x }
-
         # Convert the tasks into Datadog events
         @tasks.map do |task|
           name  = task[:name]
@@ -109,7 +107,7 @@ module Capistrano
             application = ' for ' + task[:application]
           end
           title = "#{user}@#{hostname} ran #{name}#{application} on #{roles.join(', ')} "\
-                  "with capistrano in #{task[:timing].round(2)} secs"
+                  "with capistrano in #{task[:timing].to_f.round(2)} secs"
           type  = 'deploy'
           alert_type = 'success'
           source_type = 'capistrano'


### PR DESCRIPTION
In some circumstances (a failing task notably), the `:timing` key might be missing. 

```ruby
Could not submit to Datadog: #<NoMethodError: undefined method `round' for nil:NilClass>
/app/data/bundler/ruby/2.4.0/gems/dogapi-1.28.0/lib/capistrano/datadog.rb:112:in `block in report'
/app/data/bundler/ruby/2.4.0/gems/dogapi-1.28.0/lib/capistrano/datadog.rb:100:in `map'
/app/data/bundler/ruby/2.4.0/gems/dogapi-1.28.0/lib/capistrano/datadog.rb:100:in `report'
/app/data/bundler/ruby/2.4.0/gems/dogapi-1.28.0/lib/capistrano/datadog.rb:29:in `submit'
/app/data/bundler/ruby/2.4.0/gems/dogapi-1.28.0/lib/capistrano/datadog/v3.rb:79:in `block in <top (required)>'
```