### PR TITLE
[dash list] Rename methods for consistency with Python API lib

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -279,39 +279,39 @@ module Dogapi
     #
 
     def create_dashboard_list(name)
-      @dashboard_list_service.create_dashboard_list(name)
+      @dashboard_list_service.create(name)
     end
 
     def update_dashboard_list(dashboard_list_id, name)
-      @dashboard_list_service.update_dashboard_list(dashboard_list_id, name)
+      @dashboard_list_service.update(dashboard_list_id, name)
     end
 
     def get_dashboard_list(dashboard_list_id)
-      @dashboard_list_service.get_dashboard_list(dashboard_list_id)
+      @dashboard_list_service.get(dashboard_list_id)
     end
 
     def get_all_dashboard_lists()
-      @dashboard_list_service.all_dashboard_lists()
+      @dashboard_list_service.get_all()
     end
 
     def delete_dashboard_list(dashboard_list_id)
-      @dashboard_list_service.delete_dashboard_list(dashboard_list_id)
+      @dashboard_list_service.delete(dashboard_list_id)
     end
 
-    def add_dashboards_to_dashboard_list(dashboard_list_id, dashboards)
-      @dashboard_list_service.add_dashboards_to_dashboard_list(dashboard_list_id, dashboards)
+    def add_items_to_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service.add_items(dashboard_list_id, dashboards)
     end
 
-    def update_dashboards_of_dashboard_list(dashboard_list_id, dashboards)
-      @dashboard_list_service.update_dashboards_of_dashboard_list(dashboard_list_id, dashboards)
+    def update_items_of_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service.update_items(dashboard_list_id, dashboards)
     end
 
-    def delete_dashboards_from_dashboard_list(dashboard_list_id, dashboards)
-      @dashboard_list_service.delete_dashboards_from_dashboard_list(dashboard_list_id, dashboards)
+    def delete_items_from_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service.delete_items(dashboard_list_id, dashboards)
     end
 
-    def get_dashboards_for_dashboard_list(dashboard_list_id)
-      @dashboard_list_service.get_dashboards_for_dashboard_list(dashboard_list_id)
+    def get_items_of_dashboard_list(dashboard_list_id)
+      @dashboard_list_service.get_items(dashboard_list_id)
     end
 
     #

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -291,7 +291,7 @@ module Dogapi
     end
 
     def get_all_dashboard_lists()
-      @dashboard_list_service.get_all()
+      @dashboard_list_service.all()
     end
 
     def delete_dashboard_list(dashboard_list_id)

--- a/lib/dogapi/v1/dashboard_list.rb
+++ b/lib/dogapi/v1/dashboard_list.rb
@@ -30,7 +30,7 @@ module Dogapi
         request(Net::HTTP::Get, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}", nil, nil, false)
       end
 
-      def get_all
+      def all
         request(Net::HTTP::Get, "/api/#{API_VERSION}/#{RESOURCE_NAME}", nil, nil, false)
       end
 

--- a/lib/dogapi/v1/dashboard_list.rb
+++ b/lib/dogapi/v1/dashboard_list.rb
@@ -7,81 +7,83 @@ module Dogapi
     class DashboardListService < Dogapi::APIService
 
       API_VERSION = 'v1'
+      RESOURCE_NAME = 'dashboard/lists/manual'
+      SUB_RESOURCE_NAME = 'dashboards'
 
-      def create_dashboard_list(name)
+      def create(name)
         body = {
           name: name
         }
 
-        request(Net::HTTP::Post, "/api/#{API_VERSION}/dashboard/lists/manual", nil, body, true)
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/#{RESOURCE_NAME}", nil, body, true)
       end
 
-      def update_dashboard_list(dashboard_list_id, name)
+      def update(resource_id, name)
         body = {
           name: name
         }
 
-        request(Net::HTTP::Put, "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}", nil, body, true)
+        request(Net::HTTP::Put, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}", nil, body, true)
       end
 
-      def get_dashboard_list(dashboard_list_id)
-        request(Net::HTTP::Get, "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}", nil, nil, false)
+      def get(resource_id)
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}", nil, nil, false)
       end
 
-      def all_dashboard_lists
-        request(Net::HTTP::Get, "/api/#{API_VERSION}/dashboard/lists/manual", nil, nil, false)
+      def get_all
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/#{RESOURCE_NAME}", nil, nil, false)
       end
 
-      def delete_dashboard_list(dashboard_list_id)
-        request(Net::HTTP::Delete, "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}", nil, nil, false)
+      def delete(resource_id)
+        request(Net::HTTP::Delete, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}", nil, nil, false)
       end
 
-      def get_dashboards_for_dashboard_list(dashboard_list_id)
+      def get_items(resource_id)
         request(
           Net::HTTP::Get,
-          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
           nil,
           nil,
           false
         )
       end
 
-      def add_dashboards_to_dashboard_list(dashboard_list_id, dashboards)
+      def add_items(resource_id, dashboards)
         body = {
           dashboards: dashboards
         }
 
         request(
           Net::HTTP::Post,
-          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
           nil,
           body,
           true
         )
       end
 
-      def update_dashboards_of_dashboard_list(dashboard_list_id, dashboards)
+      def update_items(resource_id, dashboards)
         body = {
           dashboards: dashboards
         }
 
         request(
           Net::HTTP::Put,
-          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
           nil,
           body,
           true
         )
       end
 
-      def delete_dashboards_from_dashboard_list(dashboard_list_id, dashboards)
+      def delete_items(resource_id, dashboards)
         body = {
           dashboards: dashboards
         }
 
         request(
           Net::HTTP::Delete,
-          "/api/#{API_VERSION}/dashboard/lists/manual/#{dashboard_list_id}/dashboards",
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
           nil,
           body,
           true

--- a/spec/integration/dashboard_list_spec.rb
+++ b/spec/integration/dashboard_list_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../spec_helper'
 
 describe Dogapi::Client do
+  RESOURCE_NAME = 'dashboard/lists/manual'.freeze
+  SUB_RESOURCE_NAME = 'dashboards'.freeze
+
   DASHBOARD_LIST_ID = 1_234_567
   DASHBOARD_LIST_NAME = 'My new dashboard list'.freeze
 
@@ -26,54 +29,57 @@ describe Dogapi::Client do
   describe '#create_dashboard_list' do
     it_behaves_like 'an api method',
                     :create_dashboard_list, [DASHBOARD_LIST_NAME],
-                    :post, '/dashboard/lists/manual', DASHBOARD_LIST_BODY
+                    :post, "/#{RESOURCE_NAME}", DASHBOARD_LIST_BODY
   end
 
   describe '#update_dashboard_list' do
     it_behaves_like 'an api method',
                     :update_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARD_LIST_NAME],
-                    :put, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}", DASHBOARD_LIST_BODY
+                    :put, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}", DASHBOARD_LIST_BODY
   end
 
   describe '#get_dashboard_list' do
     it_behaves_like 'an api method',
                     :get_dashboard_list, [DASHBOARD_LIST_ID],
-                    :get, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}"
+                    :get, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}"
   end
 
   describe '#get_all_dashboard_lists' do
     it_behaves_like 'an api method',
                     :get_all_dashboard_lists, [],
-                    :get, '/dashboard/lists/manual'
+                    :get, "/#{RESOURCE_NAME}"
   end
 
   describe '#delete_dashboard_list' do
     it_behaves_like 'an api method',
                     :delete_dashboard_list, [DASHBOARD_LIST_ID],
-                    :delete, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}"
+                    :delete, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}"
   end
 
-  describe '#add_dashboards_to_dashboard_list' do
+  describe '#add_items_to_dashboard_list' do
     it_behaves_like 'an api method',
-                    :add_dashboards_to_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
-                    :post, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards", DASHBOARD_LIST_WITH_DASHES_BODY
+                    :add_items_to_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :post, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}",
+                    DASHBOARD_LIST_WITH_DASHES_BODY
   end
 
-  describe '#update_dashboards_of_dashboard_list' do
+  describe '#update_items_of_dashboard_list' do
     it_behaves_like 'an api method',
-                    :update_dashboards_of_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
-                    :put, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards", DASHBOARD_LIST_WITH_DASHES_BODY
+                    :update_items_of_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :put, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}",
+                    DASHBOARD_LIST_WITH_DASHES_BODY
   end
 
-  describe '#delete_dashboards_from_dashboard_list' do
+  describe '#delete_items_from_dashboard_list' do
     it_behaves_like 'an api method',
-                    :delete_dashboards_from_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
-                    :delete, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards", DASHBOARD_LIST_WITH_DASHES_BODY
+                    :delete_items_from_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :delete, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}",
+                    DASHBOARD_LIST_WITH_DASHES_BODY
   end
 
-  describe '#get_dashboards_for_dashboard_list' do
+  describe '#get_items_of_dashboard_list' do
     it_behaves_like 'an api method',
-                    :get_dashboards_for_dashboard_list, [DASHBOARD_LIST_ID],
-                    :get, "/dashboard/lists/manual/#{DASHBOARD_LIST_ID}/dashboards"
+                    :get_items_of_dashboard_list, [DASHBOARD_LIST_ID],
+                    :get, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}"
   end
 end


### PR DESCRIPTION
Renames some methods for the new dashboard list endpoints to be consistent with our Python library (https://github.com/DataDog/datadogpy).
