### PR TITLE
Show more friendly error message with non JSON responses

### DIFF
--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -148,7 +148,11 @@ module Dogapi
       begin
         return resp.code, MultiJson.load(resp.body)
       rescue
-        raise 'Invalid JSON Response: ' + resp.body
+        if resp.content_type != "application/json"
+          raise "Response Content-Type is not application/json but is #{resp.content_type}: " + resp.body
+        else
+          raise 'Invalid JSON Response: ' + resp.body
+        end
       end
     end
   end

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -148,11 +148,9 @@ module Dogapi
       begin
         return resp.code, MultiJson.load(resp.body)
       rescue
-        if resp.content_type != "application/json"
-          raise "Response Content-Type is not application/json but is #{resp.content_type}: " + resp.body
-        else
-          raise 'Invalid JSON Response: ' + resp.body
-        end
+        is_json = resp.content_type == 'application/json'
+        raise "Response Content-Type is not application/json but is #{resp.content_type}: " + resp.body unless is_json
+        raise 'Invalid JSON Response: ' + resp.body
       end
     end
   end

--- a/spec/unit/common_spec.rb
+++ b/spec/unit/common_spec.rb
@@ -41,11 +41,12 @@ describe 'Common' do
 end
 
 class FakeResponse
-  attr_accessor :code, :body
-  def initialize(code, body)
+  attr_accessor :code, :body, :content_type
+  def initialize(code, body, content_type = "application/json")
     # Instance variables
     @code = code
     @body = body
+    @content_type = content_type
   end
 end
 
@@ -84,6 +85,13 @@ describe Dogapi::APIService do
         dog = dogapi_service
         resp = FakeResponse.new 202, "{'test2': }"
         expect { dog.handle_response(resp) }.to raise_error(RuntimeError, "Invalid JSON Response: {'test2': }")
+      end
+    end
+    context 'when receiving a non json response' do
+      it 'raises an error indicating the response Content-Type' do
+        dog = dogapi_service
+        resp = FakeResponse.new 202, "<html><body><h1>403 Forbidden</h1>", "text/html"
+        expect { dog.handle_response(resp) }.to raise_error(RuntimeError, "Response Content-Type is not application/json but is text/html: <html><body><h1>403 Forbidden</h1>")
       end
     end
     context 'when receiving a bad response' do

--- a/spec/unit/common_spec.rb
+++ b/spec/unit/common_spec.rb
@@ -42,7 +42,7 @@ end
 
 class FakeResponse
   attr_accessor :code, :body, :content_type
-  def initialize(code, body, content_type = "application/json")
+  def initialize(code, body, content_type = 'application/json')
     # Instance variables
     @code = code
     @body = body
@@ -90,8 +90,9 @@ describe Dogapi::APIService do
     context 'when receiving a non json response' do
       it 'raises an error indicating the response Content-Type' do
         dog = dogapi_service
-        resp = FakeResponse.new 202, "<html><body><h1>403 Forbidden</h1>", "text/html"
-        expect { dog.handle_response(resp) }.to raise_error(RuntimeError, "Response Content-Type is not application/json but is text/html: <html><body><h1>403 Forbidden</h1>")
+        resp = FakeResponse.new 202, '<html><body><h1>403 Forbidden</h1>', 'text/html'
+        msg = 'Response Content-Type is not application/json but is text/html: <html><body><h1>403 Forbidden</h1>'
+        expect { dog.handle_response(resp) }.to raise_error(RuntimeError, msg)
       end
     end
     context 'when receiving a bad response' do


### PR DESCRIPTION
I recently encountered a situation where Datadog API server responded to a JSON API request with status code 500, which is perfectly fine, but the problem was that even though the request was sent as `Content-Type: application/json` the response from the API server was `Content-Type: text/html` with obviously a 500 error HTML as the body. 

I personally think when an error occurs while handling JSON request it should return error response in JSON format, indeed with `Content-Type: application/json` as the request indicates, yet, this behavior strongly depends on how the API server is implemented, and is not something that client library should be aware of. That said, I think the current error message, `"Invalid JSON Response"` does not communicate well in such situation, and should show such errors with an error message that better describes what happened.
