### PR TITLE
Pass the options as params to request

### DIFF
--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -1,6 +1,5 @@
 require 'cgi'
 require 'net/https'
-require 'pp'
 require 'socket'
 require 'uri'
 

--- a/lib/dogapi/v1/hosts.rb
+++ b/lib/dogapi/v1/hosts.rb
@@ -9,7 +9,7 @@ module Dogapi
       API_VERSION = 'v1'
 
       def search(options = {})
-        request(Net::HTTP::Get, "/api/#{API_VERSION}/hosts", nil, options, true)
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/hosts", options, nil, true)
       end
 
       def totals


### PR DESCRIPTION
The options var should be injected as extra_params, not as a body-content.