### PR TITLE
timing should always be a float, even when a prior exception breaks b…

### DIFF
--- a/lib/capistrano/datadog.rb
+++ b/lib/capistrano/datadog.rb
@@ -69,7 +69,7 @@ module Capistrano
         timing = Benchmark.measure(task_name) do
           result = yield
         end
-        task[:timing] = timing.real
+        task[:timing] = Float(timing.real)
         @task_stack.pop
         result
       end


### PR DESCRIPTION
…enchmarking

workaround for #148