### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/dogapi.gemspec
+++ b/dogapi.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://datadoghq.com/'
   spec.license       = 'BSD'
 
+  spec.metadata      = {
+                         'bug_tracker_uri'   => 'https://github.com/DataDog/dogapi-rb/issues',
+                         'changelog_uri'     => 'https://github.com/DataDog/dogapi-rb/blob/master/CHANGELOG.md',
+                         'documentation_uri' => 'https://docs.datadoghq.com/api/',
+                         'source_code_uri'   => 'https://github.com/DataDog/dogapi-rb',
+                       }
+
   spec.files         = `git ls-files`.split($\)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})

--- a/dogapi.gemspec
+++ b/dogapi.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |spec|
   spec.license       = 'BSD'
 
   spec.metadata      = {
-                         'bug_tracker_uri'   => 'https://github.com/DataDog/dogapi-rb/issues',
-                         'changelog_uri'     => 'https://github.com/DataDog/dogapi-rb/blob/master/CHANGELOG.md',
-                         'documentation_uri' => 'https://docs.datadoghq.com/api/',
-                         'source_code_uri'   => 'https://github.com/DataDog/dogapi-rb',
-                       }
+    'bug_tracker_uri'   => 'https://github.com/DataDog/dogapi-rb/issues',
+    'changelog_uri'     => 'https://github.com/DataDog/dogapi-rb/blob/master/CHANGELOG.md',
+    'documentation_uri' => 'https://docs.datadoghq.com/api/',
+    'source_code_uri'   => 'https://github.com/DataDog/dogapi-rb'
+  }
 
   spec.files         = `git ls-files`.split($\)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, read documentation, raise issues, analyse the changelog. These links will appear on the rubygems page at https://rubygems.org/gems/dogapi after the next release.