### PR TITLE
Add monitor and monitor groups search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 1.32.0 / 2018-10-13
+
+* Add [monitor search](https://docs.datadoghq.com/api/?lang=python#monitors-search) and [monitor groups search](https://docs.datadoghq.com/api/?lang=python#monitors-group-search) API endpoints.
+
 ## 1.31.0 / 2018-10-01
 
 * [FIX] Handle nil values from benchmarks in Capistrano. See [#159][].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## 1.32.0 / 2018-10-13
+## 1.32.0 / Unreleased
 
 * Add [monitor search](https://docs.datadoghq.com/api/?lang=ruby#monitors-search) and [monitor groups search](https://docs.datadoghq.com/api/?lang=ruby#monitors-group-search) API endpoints.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.32.0 / 2018-10-13
 
-* Add [monitor search](https://docs.datadoghq.com/api/?lang=python#monitors-search) and [monitor groups search](https://docs.datadoghq.com/api/?lang=python#monitors-group-search) API endpoints.
+* Add [monitor search](https://docs.datadoghq.com/api/?lang=ruby#monitors-search) and [monitor groups search](https://docs.datadoghq.com/api/?lang=ruby#monitors-group-search) API endpoints.
 
 ## 1.31.0 / 2018-10-01
 

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -476,6 +476,14 @@ module Dogapi
       @monitor_svc.unmute_monitor(monitor_id, options)
     end
 
+    def search_monitors(options = {})
+      @monitor_svc.search_monitors(options)
+    end
+
+    def search_monitor_groups(options = {})
+      @monitor_svc.search_monitor_groups(options)
+    end
+
     #
     # MONITOR DOWNTIME
     #

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -83,6 +83,14 @@ module Dogapi
         request(Net::HTTP::Post, "/api/#{API_VERSION}/monitor/#{monitor_id}/unmute", nil, options, true)
       end
 
+      def search_monitors(options = {})
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/monitor/search", options, nil, false)
+      end
+
+      def search_monitor_groups(options = {})
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/monitor/groups/search", options, nil, false)
+      end
+
       #
       # DOWNTIMES
 

--- a/lib/dogapi/version.rb
+++ b/lib/dogapi/version.rb
@@ -1,3 +1,3 @@
 module Dogapi
-  VERSION = '1.31.0'
+  VERSION = '1.32.0'
 end


### PR DESCRIPTION
Adds monitor search and monitor groups search API endpoints.

Docs:
https://docs.datadoghq.com/api/?lang=ruby#monitors-search
https://docs.datadoghq.com/api/?lang=ruby#monitors-group-search