### PR TITLE
Add submission types mentioned in the API documentation

### DIFF
--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -61,7 +61,7 @@ module Dogapi
         begin
           typ = options[:type] || 'gauge'
 
-          if typ != 'gauge' && typ != 'counter' && typ != 'count' && typ != 'rate 
+          if typ != 'gauge' && typ != 'counter' && typ != 'count' && typ != 'rate'
             raise ArgumentError, 'metric type must be gauge or counter or count or rate'
           end
 

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -61,8 +61,8 @@ module Dogapi
         begin
           typ = options[:type] || 'gauge'
 
-          if typ != 'gauge' && typ != 'counter'
-            raise ArgumentError, 'metric type must be gauge or counter'
+          if typ != 'gauge' && typ != 'counter' && typ != 'count' && typ != 'rate 
+            raise ArgumentError, 'metric type must be gauge or counter or count or rate'
           end
 
           metric_payload = {


### PR DESCRIPTION
**Issue:** https://github.com/DataDog/dogapi-rb/issues/154
Is blocking metrics that are not of type `undefined, counter, or gauge` from appearing in app and/or with the correct metadata type.

**Fix:** Add submission types mentioned in the API documentation

**Documentation:** https://docs.datadoghq.com/developers/metrics/