### PR TITLE
Remove deprecated has_rdoc from the gemspec

### DIFF
--- a/dogapi.gemspec
+++ b/dogapi.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.has_rdoc = true
   spec.extra_rdoc_files = ['README.rdoc']
   spec.rdoc_options << '--title' << 'DogAPI -- Datadog Client' <<
                     '--main' << 'README.rdoc' <<


### PR DESCRIPTION
Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.