### PR TITLE
[dashboards] Add support for the new Dashboard API

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -282,15 +282,13 @@ module Dogapi
     #
 
     # Create a dashboard.
-    def create_board(title, widgets, description = nil, is_read_only = false, notify_list = nil, template_variables = nil)
-      @dashboard_service.create_board(title, widgets, description, is_read_only, notify_list, template_variables)
+    def create_board(title, widgets, layout_type, options= {})
+      @dashboard_service.create_board(title, widgets, layout_type, options)
     end
 
     # Update a dashboard.
-    def update_board(dashboard_id, title, widgets, description = nil, is_read_only = false, notify_list = nil,
-                     template_variables = nil)
-      @dashboard_service.update_board(dashboard_id, title, widgets, description, is_read_only, notify_list,
-                                      template_variables)
+    def update_board(dashboard_id, title, widgets, layout_type, options= {})
+      @dashboard_service.update_board(dashboard_id, title, widgets, layout_type, options)
     end
 
     # Fetch the given dashboard.

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -34,6 +34,7 @@ module Dogapi
       @comment_svc = Dogapi::V1::CommentService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @search_svc = Dogapi::V1::SearchService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @dash_service = Dogapi::V1::DashService.new(@api_key, @application_key, silent, timeout, @datadog_host)
+      @dashboard_service = Dogapi::V1::DashboardService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @dashboard_list_service = Dogapi::V1::DashboardListService.new(
         @api_key, @application_key, silent, timeout, @datadog_host
       )
@@ -274,6 +275,30 @@ module Dogapi
     # Delete the given dashboard.
     def delete_dashboard(dash_id)
       @dash_service.delete_dashboard(dash_id)
+    end
+
+    #
+    # DASHBOARDS
+    #
+
+    # Create a dashboard.
+    def create_board(title, widgets, description = nil, is_read_only = false, notify_list = nil, template_variables = nil)
+      @dashboard_service.create_board(title, widgets, description, is_read_only, notify_list, template_variables)
+    end
+
+    # Update a dashboard.
+    def update_board(dashboard_id, title, widgets, description = nil, is_read_only = false, notify_list = nil, template_variables = nil)
+      @dashboard_service.update_board(dashboard_id, title, widgets, description, is_read_only, notify_list, template_variables)
+    end
+
+    # Fetch the given dashboard.
+    def get_board(dashboard_id)
+      @dashboard_service.get_board(dashboard_id)
+    end
+
+    # Delete the given dashboard.
+    def delete_board(dashboard_id)
+      @dashboard_service.delete_board(dashboard_id)
     end
 
     #

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -287,8 +287,10 @@ module Dogapi
     end
 
     # Update a dashboard.
-    def update_board(dashboard_id, title, widgets, description = nil, is_read_only = false, notify_list = nil, template_variables = nil)
-      @dashboard_service.update_board(dashboard_id, title, widgets, description, is_read_only, notify_list, template_variables)
+    def update_board(dashboard_id, title, widgets, description = nil, is_read_only = false, notify_list = nil,
+                     template_variables = nil)
+      @dashboard_service.update_board(dashboard_id, title, widgets, description, is_read_only, notify_list,
+                                      template_variables)
     end
 
     # Fetch the given dashboard.

--- a/lib/dogapi/v1.rb
+++ b/lib/dogapi/v1.rb
@@ -1,6 +1,7 @@
 require 'dogapi/v1/alert'
 require 'dogapi/v1/comment'
 require 'dogapi/v1/dash'
+require 'dogapi/v1/dashboard'
 require 'dogapi/v1/dashboard_list'
 require 'dogapi/v1/embed'
 require 'dogapi/v1/event'

--- a/lib/dogapi/v1/dashboard.rb
+++ b/lib/dogapi/v1/dashboard.rb
@@ -11,55 +11,63 @@ module Dogapi
 
       # Create new dashboard
       #
+      # Required arguments:
       # :title                 => String: Title of the dashboard
       # :widgets               => JSON: List of widgets to display on the dashboard
+      # :layout_type           => String: Layout type of the dashboard
+      #                           (for now, only "ordered" layout - current timeboard layout - is supported)
+      # Optional arguments:
       # :description           => String: Description of the dashboard
       # :is_read_only          => Boolean: Whether this dashboard is read-only.
       #                           If True, only the author and admins can make changes to it.
       # :notify_list           => JSON: List of handles of users to notify when changes are made to this dashboard
       #                           e.g. '["user1@domain.com", "user2@domain.com"]'
       # :template_variables    => JSON: List of template variables for this dashboard.
-      #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]'
-      def create_board(title, widgets, description, is_read_only, notify_list, template_variables)
+      #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]
+      def create_board(title, widgets, layout_type, options)
         # Required arguments
         body = {
           title: title,
           widgets: widgets,
-          layout_type: 'ordered'
+          layout_type: layout_type
         }
         # Optional arguments
-        body[:description] = description if description
-        body[:is_read_only] = is_read_only if is_read_only
-        body[:notify_list] = notify_list if notify_list
-        body[:template_variables] = template_variables if template_variables
+        body[:description] = options[:description] if options[:description]
+        body[:is_read_only] = options[:is_read_only] if options[:is_read_only]
+        body[:notify_list] = options[:notify_list] if options[:notify_list]
+        body[:template_variables] = options[:template_variables] if options[:template_variables]
 
         request(Net::HTTP::Post, "/api/#{API_VERSION}/#{RESOURCE_NAME}", nil, body, true)
       end
 
       # Update a dashboard
       #
+      # Required arguments:
       # :dashboard_id          => String: ID of the dashboard
       # :title                 => String: Title of the dashboard
       # :widgets               => JSON: List of widgets to display on the dashboard
+      # :layout_type           => String: Layout type of the dashboard
+      #                           (for now, only "ordered" layout - current timeboard layout - is supported)
+      # Optional arguments:
       # :description           => String: Description of the dashboard
       # :is_read_only          => Boolean: Whether this dashboard is read-only.
       #                           If True, only the author and admins can make changes to it.
       # :notify_list           => JSON: List of handles of users to notify when changes are made to this dashboard
       #                           e.g. '["user1@domain.com", "user2@domain.com"]'
       # :template_variables    => JSON: List of template variables for this dashboard.
-      #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]'
-      def update_board(dashboard_id, title, widgets, description, is_read_only, notify_list, template_variables)
+      #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]
+      def update_board(dashboard_id, title, widgets, layout_type, options)
         # Required arguments
         body = {
           title: title,
           widgets: widgets,
-          layout_type: 'ordered'
+          layout_type: layout_type
         }
         # Optional arguments
-        body[:description] = description if description
-        body[:is_read_only] = is_read_only if is_read_only
-        body[:notify_list] = notify_list if notify_list
-        body[:template_variables] = template_variables if template_variables
+        body[:description] = options[:description] if options[:description]
+        body[:is_read_only] = options[:is_read_only] if options[:is_read_only]
+        body[:notify_list] = options[:notify_list] if options[:notify_list]
+        body[:template_variables] = options[:template_variables] if options[:template_variables]
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{dashboard_id}", nil, body, true)
       end

--- a/lib/dogapi/v1/dashboard.rb
+++ b/lib/dogapi/v1/dashboard.rb
@@ -3,6 +3,7 @@ require 'dogapi'
 module Dogapi
   class V1 # for namespacing
 
+    # Dashboard API
     class DashboardService < Dogapi::APIService
 
       API_VERSION = 'v1'
@@ -12,7 +13,7 @@ module Dogapi
       #
       # :title                 => String: Title of the dashboard
       # :widgets               => JSON: List of widgets to display on the dashboard
-      # :Description           => String: Description of the dashboard
+      # :description           => String: Description of the dashboard
       # :is_read_only          => Boolean: Whether this dashboard is read-only.
       #                           If True, only the author and admins can make changes to it.
       # :notify_list           => JSON: List of handles of users to notify when changes are made to this dashboard
@@ -20,12 +21,11 @@ module Dogapi
       # :template_variables    => JSON: List of template variables for this dashboard.
       #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]'
       def create_board(title, widgets, description, is_read_only, notify_list, template_variables)
-
         # Required arguments
         body = {
-          :title => title,
-          :widgets => widgets,
-          :layout_type => "ordered"
+          title: title,
+          widgets: widgets,
+          layout_type: 'ordered'
         }
         # Optional arguments
         body[:description] = description if description
@@ -41,7 +41,7 @@ module Dogapi
       # :dashboard_id          => String: ID of the dashboard
       # :title                 => String: Title of the dashboard
       # :widgets               => JSON: List of widgets to display on the dashboard
-      # :Description           => String: Description of the dashboard
+      # :description           => String: Description of the dashboard
       # :is_read_only          => Boolean: Whether this dashboard is read-only.
       #                           If True, only the author and admins can make changes to it.
       # :notify_list           => JSON: List of handles of users to notify when changes are made to this dashboard
@@ -49,17 +49,17 @@ module Dogapi
       # :template_variables    => JSON: List of template variables for this dashboard.
       #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]'
       def update_board(dashboard_id, title, widgets, description, is_read_only, notify_list, template_variables)
-          # Required arguments
-          body = {
-            :title => title,
-            :widgets => widgets,
-            :layout_type => "ordered"
-          }
-          # Optional arguments
-          body[:description] = description if description
-          body[:is_read_only] = is_read_only if is_read_only
-          body[:notify_list] = notify_list if notify_list
-          body[:template_variables] = template_variables if template_variables
+        # Required arguments
+        body = {
+          title: title,
+          widgets: widgets,
+          layout_type: 'ordered'
+        }
+        # Optional arguments
+        body[:description] = description if description
+        body[:is_read_only] = is_read_only if is_read_only
+        body[:notify_list] = notify_list if notify_list
+        body[:template_variables] = template_variables if template_variables
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{dashboard_id}", nil, body, true)
       end

--- a/lib/dogapi/v1/dashboard.rb
+++ b/lib/dogapi/v1/dashboard.rb
@@ -1,0 +1,84 @@
+require 'dogapi'
+
+module Dogapi
+  class V1 # for namespacing
+
+    class DashboardService < Dogapi::APIService
+
+      API_VERSION = 'v1'
+      RESOURCE_NAME = 'dashboard'
+
+      # Create new dashboard
+      #
+      # :title                 => String: Title of the dashboard
+      # :widgets               => JSON: List of widgets to display on the dashboard
+      # :Description           => String: Description of the dashboard
+      # :is_read_only          => Boolean: Whether this dashboard is read-only.
+      #                           If True, only the author and admins can make changes to it.
+      # :notify_list           => JSON: List of handles of users to notify when changes are made to this dashboard
+      #                           e.g. '["user1@domain.com", "user2@domain.com"]'
+      # :template_variables    => JSON: List of template variables for this dashboard.
+      #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]'
+      def create_board(title, widgets, description, is_read_only, notify_list, template_variables)
+
+        # Required arguments
+        body = {
+          :title => title,
+          :widgets => widgets,
+          :layout_type => "ordered"
+        }
+        # Optional arguments
+        body[:description] = description if description
+        body[:is_read_only] = is_read_only if is_read_only
+        body[:notify_list] = notify_list if notify_list
+        body[:template_variables] = template_variables if template_variables
+
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/#{RESOURCE_NAME}", nil, body, true)
+      end
+
+      # Update a dashboard
+      #
+      # :dashboard_id          => String: ID of the dashboard
+      # :title                 => String: Title of the dashboard
+      # :widgets               => JSON: List of widgets to display on the dashboard
+      # :Description           => String: Description of the dashboard
+      # :is_read_only          => Boolean: Whether this dashboard is read-only.
+      #                           If True, only the author and admins can make changes to it.
+      # :notify_list           => JSON: List of handles of users to notify when changes are made to this dashboard
+      #                           e.g. '["user1@domain.com", "user2@domain.com"]'
+      # :template_variables    => JSON: List of template variables for this dashboard.
+      #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]'
+      def update_board(dashboard_id, title, widgets, description, is_read_only, notify_list, template_variables)
+          # Required arguments
+          body = {
+            :title => title,
+            :widgets => widgets,
+            :layout_type => "ordered"
+          }
+          # Optional arguments
+          body[:description] = description if description
+          body[:is_read_only] = is_read_only if is_read_only
+          body[:notify_list] = notify_list if notify_list
+          body[:template_variables] = template_variables if template_variables
+
+        request(Net::HTTP::Put, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{dashboard_id}", nil, body, true)
+      end
+
+      # Fetch the given dashboard
+      #
+      # :dashboard_id          => String: ID of the dashboard
+      def get_board(dashboard_id)
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{dashboard_id}", nil, nil, false)
+      end
+
+      # Delete the given dashboard
+      #
+      # :dashboard_id          => String: ID of the dashboard
+      def delete_board(dashboard_id)
+        request(Net::HTTP::Delete, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{dashboard_id}", nil, nil, false)
+      end
+
+    end
+
+  end
+end

--- a/spec/integration/dashboard_spec.rb
+++ b/spec/integration/dashboard_spec.rb
@@ -23,16 +23,20 @@ describe Dogapi::Client do
     'default' => 'my-host'
   }].freeze
 
-  DASHBOARD_PAYLOAD = {
+  REQUIRED_ARGS = {
     title: TITLE,
     widgets: WIDGETS,
-    layout_type: LAYOUT_TYPE,
+    layout_type: LAYOUT_TYPE
+  }.freeze
+
+  OPTIONS = {
     description: DESCRIPTION,
     is_read_only: IS_READ_ONLY,
     notify_list: NOTIFY_LIST,
     template_variables: TEMPLATE_VARIABLES
-  }.freeze
-  DASHBOARD_ARGS = DASHBOARD_PAYLOAD.values - [LAYOUT_TYPE]
+  }
+  DASHBOARD_ARGS = REQUIRED_ARGS.values + [OPTIONS]
+  DASHBOARD_PAYLOAD = REQUIRED_ARGS.merge(OPTIONS)
 
   describe '#create_board' do
     it_behaves_like 'an api method',

--- a/spec/integration/dashboard_spec.rb
+++ b/spec/integration/dashboard_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../spec_helper'
 
 describe Dogapi::Client do
-  DASHBOARD_ID = "3er-f8j-eus".freeze
+  DASHBOARD_ID = '3er-f8j-eus'.freeze
   TITLE = 'My awesome dashboard'.freeze
   WIDGETS = [{
     'definition' => {
@@ -13,12 +13,10 @@ describe Dogapi::Client do
     },
     'id' => 1234
   }].freeze
-  LAYOUT_TYPE = "ordered".freeze
+  LAYOUT_TYPE = 'ordered'.freeze
   DESCRIPTION = 'Lorem ipsum'.freeze
   IS_READ_ONLY = true
-  NOTIFY_LIST = [
-      "user@domain.com"
-  ].freeze
+  NOTIFY_LIST = ['user@domain.com'].freeze
   TEMPLATE_VARIABLES = [{
     'name' => 'host1',
     'prefix' => 'host',

--- a/spec/integration/dashboard_spec.rb
+++ b/spec/integration/dashboard_spec.rb
@@ -1,0 +1,62 @@
+require_relative '../spec_helper'
+
+describe Dogapi::Client do
+  DASHBOARD_ID = "3er-f8j-eus".freeze
+  TITLE = 'My awesome dashboard'.freeze
+  WIDGETS = [{
+    'definition' => {
+      'requests ' => [
+        { 'q' => 'avg:system.mem.free{*}' }
+      ],
+      'title' => 'Average Memory Free',
+      'type' => 'timeseries'
+    },
+    'id' => 1234
+  }].freeze
+  LAYOUT_TYPE = "ordered".freeze
+  DESCRIPTION = 'Lorem ipsum'.freeze
+  IS_READ_ONLY = true
+  NOTIFY_LIST = [
+      "user@domain.com"
+  ].freeze
+  TEMPLATE_VARIABLES = [{
+    'name' => 'host1',
+    'prefix' => 'host',
+    'default' => 'my-host'
+  }].freeze
+
+  DASHBOARD_PAYLOAD = {
+    title: TITLE,
+    widgets: WIDGETS,
+    layout_type: LAYOUT_TYPE,
+    description: DESCRIPTION,
+    is_read_only: IS_READ_ONLY,
+    notify_list: NOTIFY_LIST,
+    template_variables: TEMPLATE_VARIABLES
+  }.freeze
+  DASHBOARD_ARGS = DASHBOARD_PAYLOAD.values - [LAYOUT_TYPE]
+
+  describe '#create_board' do
+    it_behaves_like 'an api method',
+                    :create_board, DASHBOARD_ARGS,
+                    :post, '/dashboard', DASHBOARD_PAYLOAD
+  end
+
+  describe '#update_board' do
+    it_behaves_like 'an api method',
+                    :update_board, [DASHBOARD_ID] + DASHBOARD_ARGS,
+                    :put, "/dashboard/#{DASHBOARD_ID}", DASHBOARD_PAYLOAD
+  end
+
+  describe '#get_board' do
+    it_behaves_like 'an api method',
+                    :get_board, [DASHBOARD_ID],
+                    :get, "/dashboard/#{DASHBOARD_ID}"
+  end
+
+  describe '#delete_board' do
+    it_behaves_like 'an api method',
+                    :delete_board, [DASHBOARD_ID],
+                    :delete, "/dashboard/#{DASHBOARD_ID}"
+  end
+end


### PR DESCRIPTION
This PR adds support for the following endpoints for the new dashboard API:

- Create a new dashboard: `create_board()` => `POST /api/v1dashboard`.
- Update a dashboard: `update_board()` => `PUT /api/v1dashboard/<dashboard_id>`.
- Get a dashboard : `get_board()` => `GET /api/v1dashboard/<dashboard_id>`.
- Delete a dashboard `delete_board()` => `DELETE /api/v1dashboard/<dashboard_id>`.

Notes:
- The new dashboard API will eventually replace both `timeboards` and `screenboards` APIs. 
- Since the the name `dashboard` was taken by the old timeboards API (eg: `create_dashboard`), I used the name `board` (eg: `create_board`). This might be confusing since internally I used `DashboardService` to match our API naming `/api/v1/dashboard`, but I didn't want to introduce breaking changes.
