### PR TITLE
Update the gemspec

### DIFF
--- a/dogapi.gemspec
+++ b/dogapi.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.has_rdoc = true
   spec.extra_rdoc_files = ['README.rdoc']
   spec.rdoc_options << '--title' << 'DogAPI -- Datadog Client' <<
                     '--main' << 'README.rdoc' <<
@@ -33,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'multi_json'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake', '~> 10'
   spec.add_development_dependency 'rdoc'
 end


### PR DESCRIPTION
`has_rdoc` has been deprecated and bundler 2+ works so no need to pin too aggressively