### PR TITLE
Add get_active_metrics and resolve_monitors methods for missing api endpoints

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -209,6 +209,8 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 96
+  Exclude:
+    - 'spec/integration/monitor_spec.rb'
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:
@@ -340,6 +342,7 @@ Style/Documentation:
     - 'lib/dogapi/v1/snapshot.rb'
     - 'lib/dogapi/v1/user.rb'
     - 'lib/dogapi/v1/integration.rb'
+    - 'lib/dogapi/v1/metric.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -118,6 +118,13 @@ module Dogapi
       end
     end
 
+    # Get a list of active metrics since a given time
+    # +from+ The seconds since the unix epoch <tt>[Time, Integer]</tt>
+    #
+    def get_active_metrics(from)
+      @metric_svc.get_active_metrics(from)
+    end
+
     #
     # EVENTS
 

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -514,6 +514,10 @@ module Dogapi
       @monitor_svc.unmute_monitor(monitor_id, options)
     end
 
+    def resolve_monitors(monitor_groups = [], options = {}, version = nil)
+      @monitor_svc.resolve_monitors(monitor_groups, options, version)
+    end
+
     def search_monitors(options = {})
       @monitor_svc.search_monitors(options)
     end

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -85,5 +85,13 @@ module Dogapi
       end
     end
 
+    def get_active_metrics(from)
+      params = {
+        from: from.to_i
+      }
+
+      request(Net::HTTP::Get, '/api/' + API_VERSION + '/metrics', params, nil, false)
+    end
+
   end
 end

--- a/lib/dogapi/v1/metric.rb
+++ b/lib/dogapi/v1/metric.rb
@@ -83,15 +83,14 @@ module Dogapi
           suppress_error_if_silent e
         end
       end
+
+      def get_active_metrics(from)
+        params = {
+          from: from.to_i
+        }
+
+        request(Net::HTTP::Get, '/api/' + API_VERSION + '/metrics', params, nil, false)
+      end
     end
-
-    def get_active_metrics(from)
-      params = {
-        from: from.to_i
-      }
-
-      request(Net::HTTP::Get, '/api/' + API_VERSION + '/metrics', params, nil, false)
-    end
-
   end
 end

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -83,6 +83,17 @@ module Dogapi
         request(Net::HTTP::Post, "/api/#{API_VERSION}/monitor/#{monitor_id}/unmute", nil, options, true)
       end
 
+      def resolve_monitors(monitor_groups = [], options = {}, version = nil)
+        body = {
+          'resolve' => monitor_groups
+        }.merge options
+
+        # Currently not part of v1 at this time but adding future compatibility option
+        endpoint = version.nil? ? '/api/monitor/bulk_resolve' : "/api/#{version}/monitor/bulk_resolve"
+
+        request(Net::HTTP::Post, endpoint, nil, body, true)
+      end
+
       def search_monitors(options = {})
         request(Net::HTTP::Get, "/api/#{API_VERSION}/monitor/search", options, nil, false)
       end
@@ -133,6 +144,5 @@ module Dogapi
         request(Net::HTTP::Post, "/api/#{API_VERSION}/host/#{hostname}/unmute", nil, {}, true)
       end
     end
-
   end
 end

--- a/spec/integration/metric_spec.rb
+++ b/spec/integration/metric_spec.rb
@@ -34,6 +34,7 @@ describe Dogapi::Client do
   }.freeze
 
   METRIC_PARAMS = { query: METRIC_QUERY, from: FROM.to_i, to: TO.to_i }.freeze
+  ACTIVE_METRICS_PARAMS = { from: FROM.to_i }.freeze
 
   describe '#emit_point' do
     it 'queries the api' do
@@ -92,5 +93,11 @@ describe Dogapi::Client do
         body: body
       )
     end
+  end
+
+  describe '#get_active_metrics' do
+    it_behaves_like 'an api method with params',
+                    :get_active_metrics, [],
+                    :get, '/metrics', ACTIVE_METRICS_PARAMS
   end
 end

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -7,6 +7,7 @@ describe Dogapi::Client do
   DOWNTIME_SCOPE = 'host:vagrant-ubuntu-trusty-64'.freeze
   DOWNTIME_ID = 424_242_424_242
   MUTE_HOSTNAME = 'vagrant-ubuntu-trusty-32'.freeze
+  MONITOR_GROUPS = [{ 'check_a' => 'group_x' }, { 'check_a' => 'group_y' }, { 'check_b' => 'ALL_GROUPS' }].freeze
 
   describe '#monitor' do
     it_behaves_like 'an api method with options',
@@ -66,6 +67,12 @@ describe Dogapi::Client do
     it_behaves_like 'an api method',
                     :unmute_monitor, [MONITOR_ID],
                     :post, "/monitor/#{MONITOR_ID}/unmute", {}
+  end
+
+  describe '#resolve_monitors' do
+    it_behaves_like 'an api method with options',
+                    :resolve_monitors, [MONITOR_GROUPS],
+                    :post, '/monitor/bulk_resolve', 'resolve' => MONITOR_GROUPS
   end
 
   describe '#schedule_downtime' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,17 +21,20 @@ module SpecDog
   let(:app_key) { 'APP_KEY' }
   let(:dog) { Dogapi::Client.new(api_key, app_key, 'data.dog', nil, false) }
   let(:api_url) { "#{DATADOG_HOST}/api/v1" }
+  let(:old_api_url) { "#{DATADOG_HOST}/api" }
   let(:default_query) { { api_key: api_key, application_key: app_key } }
 
   shared_examples 'an api method' do |command, args, request, endpoint, body|
     it 'queries the api' do
       url = api_url + endpoint
-      stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
+      old_url = old_api_url + endpoint
+      stub_request(request, /#{url}|#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
+      # stub_request(request, /#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(command, *args)).to eq ['200', {}]
 
       body = MultiJson.dump(body) if body
 
-      expect(WebMock).to have_requested(request, url).with(
+      expect(WebMock).to have_requested(request, /#{url}|#{old_url}/).with(
         query: default_query,
         body: body
       )
@@ -42,13 +45,15 @@ module SpecDog
     include_examples 'an api method', command, args, request, endpoint, body
     it 'queries the api with options' do
       url = api_url + endpoint
+      old_url = old_api_url + endpoint
       options = { 'zzz' => 'aaa' }
-      stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
+      stub_request(request, /#{url}|#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
+      # stub_request(request, /#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(command, *args, options)).to eq ['200', {}]
 
       body = MultiJson.dump(body ? (body.merge options) : options)
 
-      expect(WebMock).to have_requested(request, url).with(
+      expect(WebMock).to have_requested(request, /#{url}|#{old_url}/).with(
         query: default_query,
         body: body
       )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,6 @@ module SpecDog
       url = api_url + endpoint
       old_url = old_api_url + endpoint
       stub_request(request, /#{url}|#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
-      # stub_request(request, /#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(command, *args)).to eq ['200', {}]
 
       body = MultiJson.dump(body) if body
@@ -48,7 +47,6 @@ module SpecDog
       old_url = old_api_url + endpoint
       options = { 'zzz' => 'aaa' }
       stub_request(request, /#{url}|#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
-      # stub_request(request, /#{old_url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(command, *args, options)).to eq ['200', {}]
 
       body = MultiJson.dump(body ? (body.merge options) : options)


### PR DESCRIPTION
This PR addresses some of the missing ruby methods for endpoints mentioned in [open issue #137](https://github.com/DataDog/dogapi-rb/issues/137)

- Adds `get_active_metrics` for [/api/v1/metrics](https://docs.datadoghq.com/api/?lang=ruby#get-list-of-active-metrics)

- Adds `resolve_monitors` for [/monitor/bulk_resolve](https://docs.datadoghq.com/api/?lang=ruby#resolve-monitor)

_PR notes_

- I noticed the `resolve_monitors` endpoint has a deprecated url format, so tried to format the method and the tests to be extensible for future compatibility if this gets moved under the `/v1` api umbrella.

Anyways let me know what you think, happy to make any changes suggested, feedback welcome! Would like to tackle some of the other missing endpoints (usage/integrations/etc) when I have bandwidth but figured i'd try to get these out the door first.

~Eric