### PR TITLE
[dashboards] Add support for dashboard list API v2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,5 +11,7 @@
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 122
+Metrics/ModuleLength:
+  Max: 200
 
 inherit_from: .rubocop_todo.yml

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -1,7 +1,50 @@
 require 'time'
 require 'dogapi/v1'
+require 'dogapi/v2'
 
 module Dogapi
+
+  # A simple DogAPI client supporting the version 2.
+  #
+  # See Dogapi::V2  for the thick underlying clients
+  class ClientV2
+    attr_accessor :datadog_host
+    def initialize(api_key, application_key=nil, host=nil, device=nil, silent=true, timeout=nil, endpoint=nil)
+
+      if api_key
+        @api_key = api_key
+      else
+        raise 'Please provide an API key to submit your data'
+      end
+
+      @application_key = application_key
+      @datadog_host = endpoint || Dogapi.find_datadog_host()
+      @host = host || Dogapi.find_localhost()
+      @device = device
+
+      @dashboard_list_service_v2 = Dogapi::V2::DashboardListService.new(
+        @api_key, @application_key, silent, timeout, @datadog_host
+      )
+
+    end
+
+    def add_items_to_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service_v2.add_items(dashboard_list_id, dashboards)
+    end
+
+    def update_items_of_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service_v2.update_items(dashboard_list_id, dashboards)
+    end
+
+    def delete_items_from_dashboard_list(dashboard_list_id, dashboards)
+      @dashboard_list_service_v2.delete_items(dashboard_list_id, dashboards)
+    end
+
+    def get_items_of_dashboard_list(dashboard_list_id)
+      @dashboard_list_service_v2.get_items(dashboard_list_id)
+    end
+
+  end
 
   # A simple DogAPI client
   #
@@ -13,6 +56,8 @@ module Dogapi
   # documentation, here[https://github.com/DataDog/dogapi/wiki].
   class Client # rubocop:disable Metrics/ClassLength
     attr_accessor :datadog_host
+    attr_accessor :v2
+    # Support for API version 2.
 
     def initialize(api_key, application_key=nil, host=nil, device=nil, silent=true, timeout=nil, endpoint=nil)
 
@@ -50,6 +95,10 @@ module Dogapi
       @hosts_svc = Dogapi::V1::HostsService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @integration_svc = Dogapi::V1::IntegrationService.new(@api_key, @application_key, silent, timeout, @datadog_host)
       @usage_svc = Dogapi::V1::UsageService.new(@api_key, @application_key, silent, timeout, @datadog_host)
+
+      # Support for Dashboard List API v2.
+      @v2 = Dogapi::ClientV2.new(@api_key, @application_key, true, true, @datadog_host)
+
     end
 
     #

--- a/lib/dogapi/v2.rb
+++ b/lib/dogapi/v2.rb
@@ -1,0 +1,1 @@
+require 'dogapi/v2/dashboard_list'

--- a/lib/dogapi/v2/dashboard_list.rb
+++ b/lib/dogapi/v2/dashboard_list.rb
@@ -1,0 +1,68 @@
+require 'dogapi'
+
+module Dogapi
+  class V2 # for namespacing
+
+    # Dashboard List API
+    class DashboardListService < Dogapi::APIService
+
+      API_VERSION = 'v2'
+      RESOURCE_NAME = 'dashboard/lists/manual'
+      SUB_RESOURCE_NAME = 'dashboards'
+
+      def get_items(resource_id)
+        request(
+          Net::HTTP::Get,
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
+          nil,
+          nil,
+          false
+        )
+      end
+
+      def add_items(resource_id, dashboards)
+        body = {
+          dashboards: dashboards
+        }
+
+        request(
+          Net::HTTP::Post,
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
+          nil,
+          body,
+          true
+        )
+      end
+
+      def update_items(resource_id, dashboards)
+        body = {
+          dashboards: dashboards
+        }
+
+        request(
+          Net::HTTP::Put,
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
+          nil,
+          body,
+          true
+        )
+      end
+
+      def delete_items(resource_id, dashboards)
+        body = {
+          dashboards: dashboards
+        }
+
+        request(
+          Net::HTTP::Delete,
+          "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{resource_id}/#{SUB_RESOURCE_NAME}",
+          nil,
+          body,
+          true
+        )
+      end
+
+    end
+
+  end
+end

--- a/spec/integration/dashboard_list_spec.rb
+++ b/spec/integration/dashboard_list_spec.rb
@@ -6,7 +6,6 @@ describe Dogapi::Client do
 
   DASHBOARD_LIST_ID = 1_234_567
   DASHBOARD_LIST_NAME = 'My new dashboard list'.freeze
-
   DASHBOARDS = [
     {
       'type' => 'custom_timeboard',
@@ -79,6 +78,51 @@ describe Dogapi::Client do
 
   describe '#get_items_of_dashboard_list' do
     it_behaves_like 'an api method',
+                    :get_items_of_dashboard_list, [DASHBOARD_LIST_ID],
+                    :get, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}"
+  end
+end
+
+describe Dogapi::ClientV2 do
+  RESOURCE_NAME = 'dashboard/lists/manual'.freeze
+  SUB_RESOURCE_NAME = 'dashboards'.freeze
+
+  DASHBOARD_LIST_ID = 1_234_567
+  DASHBOARD_LIST_NAME = 'My new dashboard list'.freeze
+  DASHBOARDS = [
+    {
+      'type' => 'custom_timeboard',
+      'id' => 1234
+    },
+    {
+      'type' => 'custom_screenboard',
+      'id' => 1234
+    }
+  ].freeze
+
+  describe '#add_items_to_dashboard_list' do
+    it_behaves_like 'an api v2 method',
+                    :add_items_to_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :post, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}",
+                    DASHBOARD_LIST_WITH_DASHES_BODY
+  end
+
+  describe '#update_items_of_dashboard_list' do
+    it_behaves_like 'an api v2 method',
+                    :update_items_of_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :put, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}",
+                    DASHBOARD_LIST_WITH_DASHES_BODY
+  end
+
+  describe '#delete_items_from_dashboard_list' do
+    it_behaves_like 'an api v2 method',
+                    :delete_items_from_dashboard_list, [DASHBOARD_LIST_ID] + [DASHBOARDS],
+                    :delete, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}",
+                    DASHBOARD_LIST_WITH_DASHES_BODY
+  end
+
+  describe '#get_items_of_dashboard_list' do
+    it_behaves_like 'an api v2 method',
                     :get_items_of_dashboard_list, [DASHBOARD_LIST_ID],
                     :get, "/#{RESOURCE_NAME}/#{DASHBOARD_LIST_ID}/#{SUB_RESOURCE_NAME}"
   end


### PR DESCRIPTION
Add new API calls (v2):
- `dog.v2.add_items_to_dashboard_list`
- `dog.v2.get_items_of_dashboard_list`
- `dog.v2.update_items_of_dashboard_list`
- `dog.v2.delete_items_from_dashboard_list` 