### PR TITLE
Do not assume hostname binary is available

### DIFF
--- a/lib/capistrano/datadog.rb
+++ b/lib/capistrano/datadog.rb
@@ -90,7 +90,7 @@ module Capistrano
       end
 
       def report()
-        hostname = %x[hostname -f].strip
+        hostname = Dogapi.find_localhost
         user = Etc.getlogin
 
         # Lazy randomness

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -164,7 +164,7 @@ module Dogapi
 
   def Dogapi.find_localhost
     begin
-      @@hostname ||= Socket.gethostname.strip
+      @@hostname ||= Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
     rescue
       raise 'Cannot determine local hostname via Socket.gethostname'
     end

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -2,6 +2,7 @@ require 'cgi'
 require 'net/https'
 require 'socket'
 require 'uri'
+require 'English'
 
 require 'rubygems'
 require 'multi_json'
@@ -163,10 +164,9 @@ module Dogapi
   @@hostname = nil
 
   def Dogapi.find_localhost
-    begin
-      @@hostname ||= Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
-    rescue
-      raise 'Cannot determine local hostname via Socket.gethostname'
-    end
+    @@hostname ||= %x[hostname -f].strip
+  rescue SystemCallError
+    raise $ERROR_INFO unless $ERROR_INFO.class.name == 'Errno::ENOENT'
+    @@hostname = Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
   end
 end

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -164,10 +164,9 @@ module Dogapi
 
   def Dogapi.find_localhost
     begin
-      # prefer hostname -f over Socket.gethostname
-      @@hostname ||= %x[hostname -f].strip
+      @@hostname ||= Socket.gethostname.strip
     rescue
-      raise 'Cannot determine local hostname via hostname -f'
+      raise 'Cannot determine local hostname via Socket.gethostname'
     end
   end
 end


### PR DESCRIPTION
We run this code in AWS Lambda. AWS recently removed the `hostname` binary from the execution environment.