### PR TITLE
Use headers only for api and app keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 1.37.0 / 2019-09-24
+
+* [FEATURE] Pass api and application keys to datadog from headers only
+
 ## 1.36.0 / 2019-06-05
 
 * [BUGFIX] Pass the options as params to request, not body content. See [#157][], thanks [@wonko][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changes
 
-## 1.37.0 / 2019-09-24
-
-* [FEATURE] Pass api and application keys to datadog from headers only
-
 ## 1.36.0 / 2019-06-05
 
 * [BUGFIX] Pass the options as params to request, not body content. See [#157][], thanks [@wonko][]

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -117,7 +117,10 @@ module Dogapi
       connect do |conn|
         begin
           current_url = url + prepare_params(extra_params, with_app_key)
+          # current_url = url
           req = method.new(current_url)
+          req['DD-API-KEY'] = @api_key if @api_key
+          req['DD-APPLICATION_KEY'] = @application_key if @application_key
 
           if send_json
             req.content_type = 'application/json'
@@ -133,8 +136,7 @@ module Dogapi
     end
 
     def prepare_params(extra_params, with_app_key)
-      params = { api_key: @api_key }
-      params[:application_key] = @application_key if with_app_key
+      params = {}
       params = extra_params.merge params unless extra_params.nil?
       qs_params = params.map { |k, v| CGI.escape(k.to_s) + '=' + CGI.escape(v.to_s) }
       qs = '?' + qs_params.join('&')

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -117,7 +117,6 @@ module Dogapi
       connect do |conn|
         begin
           current_url = url + prepare_params(extra_params, with_app_key)
-          # current_url = url
           req = method.new(current_url)
           req['DD-API-KEY'] = @api_key if @api_key
           req['DD-APPLICATION_KEY'] = @application_key if @application_key

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -116,10 +116,10 @@ module Dogapi
       resp = nil
       connect do |conn|
         begin
-          current_url = url + prepare_params(extra_params, with_app_key)
+          current_url = url + prepare_params(extra_params)
           req = method.new(current_url)
-          req['DD-API-KEY'] = @api_key if @api_key
-          req['DD-APPLICATION_KEY'] = @application_key if @application_key
+          req['DD-API-KEY'] = @api_key
+          req['DD-APPLICATION_KEY'] = @application_key if with_app_key
 
           if send_json
             req.content_type = 'application/json'
@@ -134,7 +134,7 @@ module Dogapi
       end
     end
 
-    def prepare_params(extra_params, with_app_key)
+    def prepare_params(extra_params)
       params = {}
       params = extra_params.merge params unless extra_params.nil?
       qs_params = params.map { |k, v| CGI.escape(k.to_s) + '=' + CGI.escape(v.to_s) }

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -69,6 +69,7 @@ module Dogapi
 
   # Superclass that deals with the details of communicating with the DataDog API
   class APIService
+    attr_reader :api_key, :application_key
     def initialize(api_key, application_key, silent=true, timeout=nil, endpoint=nil)
       @api_key = api_key
       @application_key = application_key
@@ -119,7 +120,7 @@ module Dogapi
           current_url = url + prepare_params(extra_params)
           req = method.new(current_url)
           req['DD-API-KEY'] = @api_key
-          req['DD-APPLICATION_KEY'] = @application_key if with_app_key
+          req['DD-APPLICATION-KEY'] = @application_key if with_app_key
 
           if send_json
             req.content_type = 'application/json'

--- a/lib/dogapi/version.rb
+++ b/lib/dogapi/version.rb
@@ -1,3 +1,3 @@
 module Dogapi
-  VERSION = '1.36.0'
+  VERSION = '1.37.0'
 end

--- a/spec/integration/comment_spec.rb
+++ b/spec/integration/comment_spec.rb
@@ -18,9 +18,7 @@ describe Dogapi::Client do
       stub_request(:put, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(:update_comment, COMMENT_ID, options)).to eq ['200', {}]
 
-      expect(WebMock).to have_requested(:put, url).with(
-        query: default_query
-      )
+      expect(WebMock).to have_requested(:put, url)
     end
   end
 

--- a/spec/integration/common_spec.rb
+++ b/spec/integration/common_spec.rb
@@ -12,9 +12,7 @@ describe Dogapi::APIService do
           stub_request(:get, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
           expect(service.request(Net::HTTP::Get, '/api/v1/awesome', nil, nil, true, true)).to eq(['200', {}])
 
-          expect(WebMock).to have_requested(:get, url).with(
-            query: default_query
-          )
+          expect(WebMock).to have_requested(:get, url)
         end
       end
       context 'and it is down' do
@@ -22,9 +20,7 @@ describe Dogapi::APIService do
           stub_request(:get, /#{url}/).to_timeout
           expect(service.request(Net::HTTP::Get, '/api/v1/awesome', nil, nil, true, true)).to eq([-1, {}])
 
-          expect(WebMock).to have_requested(:get, url).with(
-            query: default_query
-          )
+          expect(WebMock).to have_requested(:get, url)
         end
       end
     end

--- a/spec/integration/event_spec.rb
+++ b/spec/integration/event_spec.rb
@@ -37,7 +37,6 @@ describe Dogapi::Client do
       body = MultiJson.dump(EVENT_OPTIONS)
 
       expect(WebMock).to have_requested(:post, url).with(
-        query: { 'api_key' => api_key },
         body: body
       )
     end
@@ -63,7 +62,6 @@ describe Dogapi::Client do
 
       params = STREAM_PARAMS.merge(start: EVENT_START, end: EVENT_END)
       params.each { |k, v| params[k] = v.join(',') if v.is_a? Array }
-      params.merge! default_query
 
       expect(WebMock).to have_requested(:get, url).with(
         query: params

--- a/spec/integration/metric_spec.rb
+++ b/spec/integration/metric_spec.rb
@@ -48,7 +48,6 @@ describe Dogapi::Client do
       body = MultiJson.dump(body)
 
       expect(WebMock).to have_requested(:post, url).with(
-        query: { 'api_key' => api_key },
         body: body
       )
     end
@@ -64,7 +63,6 @@ describe Dogapi::Client do
       body = MultiJson.dump(EMIT_BODY)
 
       expect(WebMock).to have_requested(:post, url).with(
-        query: { 'api_key' => api_key },
         body: body
       )
     end
@@ -89,7 +87,6 @@ describe Dogapi::Client do
       body = MultiJson.dump(BATCH_BODY)
 
       expect(WebMock).to have_requested(:post, url).with(
-        query: { 'api_key' => api_key },
         body: body
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,8 +25,6 @@ module SpecDog
   let(:old_api_url) { "#{DATADOG_HOST}/api" }
   let(:api_v2_url) { "#{DATADOG_HOST}/api/v2" }
 
-  let(:default_query) { { api_key: api_key, application_key: app_key } }
-
   shared_examples 'an api method' do |command, args, request, endpoint, body|
     it 'queries the api' do
       url = api_url + endpoint
@@ -37,7 +35,6 @@ module SpecDog
       body = MultiJson.dump(body) if body
 
       expect(WebMock).to have_requested(request, /#{url}|#{old_url}/).with(
-        query: default_query,
         body: body
       )
     end
@@ -55,7 +52,6 @@ module SpecDog
       body = MultiJson.dump(body ? (body.merge options) : options)
 
       expect(WebMock).to have_requested(request, /#{url}|#{old_url}/).with(
-        query: default_query,
         body: body
       )
     end
@@ -67,7 +63,7 @@ module SpecDog
       stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(command, *args, *params.values)).to eq ['200', {}]
       params.each { |k, v| params[k] = v.join(',') if v.is_a? Array }
-      params = params.merge default_query
+      params = params
 
       expect(WebMock).to have_requested(request, url).with(
         query: params
@@ -83,7 +79,7 @@ module SpecDog
       expect(dog.send(command, *args, opt_params)).to eq ['200', {}]
 
       opt_params.each { |k, v| opt_params[k] = v.join(',') if v.is_a? Array }
-      params = opt_params.merge default_query
+      params = opt_params
 
       expect(WebMock).to have_requested(request, url).with(
         query: params
@@ -101,7 +97,6 @@ module SpecDog
       body = MultiJson.dump(body) if body
 
       expect(WebMock).to have_requested(request, url).with(
-        query: default_query,
         body: body
       )
     end
@@ -117,7 +112,6 @@ module SpecDog
       body = MultiJson.dump(body ? (body.merge options) : options)
 
       expect(WebMock).to have_requested(request, url).with(
-        query: default_query,
         body: body
       )
     end
@@ -129,7 +123,7 @@ module SpecDog
       stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog2.send(command, *args, *params.values)).to eq ['200', {}]
       params.each { |k, v| params[k] = v.join(',') if v.is_a? Array }
-      params = params.merge default_query
+      params = params
 
       expect(WebMock).to have_requested(request, url).with(
         query: params
@@ -144,7 +138,7 @@ module SpecDog
       stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog2.send(command, *args, opt_params)).to eq ['200', {}]
       opt_params.each { |k, v| opt_params[k] = v.join(',') if v.is_a? Array }
-      params = opt_params.merge default_query
+      params = opt_params
 
       expect(WebMock).to have_requested(request, url).with(
         query: params

--- a/spec/unit/common_spec.rb
+++ b/spec/unit/common_spec.rb
@@ -43,13 +43,17 @@ describe 'Common' do
     it 'respects the endpoint configuration' do
       service = Dogapi::APIService.new('api_key', 'app_key', true, nil, 'https://app.example.com')
 
-      expect(service.api_key).to eq 'api_key'
-      expect(service.application_key).to eq 'app_key'
-
       service.connect do |conn|
         expect(conn.address).to eq 'app.example.com'
         expect(conn.port).to eq 443
       end
+    end
+
+    it 'respects http headers' do
+      service = Dogapi::APIService.new('api_key', 'app_key', true, nil, 'https://app.example.com')
+
+      expect(service.api_key).to eq 'api_key'
+      expect(service.application_key).to eq 'app_key'
     end
   end
 end

--- a/spec/unit/common_spec.rb
+++ b/spec/unit/common_spec.rb
@@ -43,7 +43,6 @@ describe 'Common' do
     it 'respects the endpoint configuration' do
       service = Dogapi::APIService.new('api_key', 'app_key', true, nil, 'https://app.example.com')
 
-      puts service.api_key.inspect
       expect(service.api_key).to eq 'api_key'
       expect(service.application_key).to eq 'app_key'
 

--- a/spec/unit/common_spec.rb
+++ b/spec/unit/common_spec.rb
@@ -43,6 +43,10 @@ describe 'Common' do
     it 'respects the endpoint configuration' do
       service = Dogapi::APIService.new('api_key', 'app_key', true, nil, 'https://app.example.com')
 
+      puts service.api_key.inspect
+      expect(service.api_key).to eq 'api_key'
+      expect(service.application_key).to eq 'app_key'
+
       service.connect do |conn|
         expect(conn.address).to eq 'app.example.com'
         expect(conn.port).to eq 443


### PR DESCRIPTION
Datadog now supports api and app keys in headers. Refactoring ruby lib to use headers only