### PR TITLE
Revert "[users] Updated users api calls to use plural endpoints"

### DIFF
--- a/lib/dogapi/v1/user.rb
+++ b/lib/dogapi/v1/user.rb
@@ -23,19 +23,19 @@ module Dogapi
       #
       # :description => Hash: user description containing 'handle' and 'name' properties
       def create_user(description= {})
-        request(Net::HTTP::Post, "/api/#{API_VERSION}/users", nil, description, true)
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/user", nil, description, true)
       end
 
       # Retrieve user information
       #
       # :handle => String: user handle
       def get_user(handle)
-        request(Net::HTTP::Get, "/api/#{API_VERSION}/users/#{handle}", nil, nil, false)
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/user/#{handle}", nil, nil, false)
       end
 
       # Retrieve all users
       def get_all_users
-        request(Net::HTTP::Get, "/api/#{API_VERSION}/users", nil, nil, false)
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/user", nil, nil, false)
       end
 
       # Update a user
@@ -44,14 +44,14 @@ module Dogapi
       # :description => Hash: user description optionally containing 'name', 'email',
       # 'is_admin', 'disabled' properties
       def update_user(handle, description= {})
-        request(Net::HTTP::Put, "/api/#{API_VERSION}/users/#{handle}", nil, description, true)
+        request(Net::HTTP::Put, "/api/#{API_VERSION}/user/#{handle}", nil, description, true)
       end
 
       # Disable a user
       #
       # :handle => String: user handle
       def disable_user(handle)
-        request(Net::HTTP::Delete, "/api/#{API_VERSION}/users/#{handle}", nil, nil, false)
+        request(Net::HTTP::Delete, "/api/#{API_VERSION}/user/#{handle}", nil, nil, false)
       end
 
     end

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -17,30 +17,30 @@ describe Dogapi::Client do
   describe '#create_user' do
     it_behaves_like 'an api method',
                     :create_user, [USER_DESCRIPTION],
-                    :post, '/users', USER_DESCRIPTION
+                    :post, '/user', USER_DESCRIPTION
   end
 
   describe '#get_user' do
     it_behaves_like 'an api method',
                     :get_user, [USER_HANDLE],
-                    :get, "/users/#{USER_HANDLE}"
+                    :get, "/user/#{USER_HANDLE}"
   end
 
   describe '#get_all_users' do
     it_behaves_like 'an api method',
                     :get_all_users, [],
-                    :get, '/users'
+                    :get, '/user'
   end
 
   describe '#update_user' do
     it_behaves_like 'an api method',
                     :update_user, [USER_HANDLE, USER_DESCRIPTION],
-                    :put, "/users/#{USER_HANDLE}", USER_DESCRIPTION
+                    :put, "/user/#{USER_HANDLE}", USER_DESCRIPTION
   end
 
   describe '#disable_user' do
     it_behaves_like 'an api method',
                     :disable_user, [USER_HANDLE],
-                    :delete, "/users/#{USER_HANDLE}"
+                    :delete, "/user/#{USER_HANDLE}"
   end
 end


### PR DESCRIPTION
Reverts DataDog/dogapi-rb#181
Going back to using the singular for v1. Plural is for v2