### PR TITLE
Revert "Use headers only for api and app keys"

### DIFF
--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -69,7 +69,6 @@ module Dogapi
 
   # Superclass that deals with the details of communicating with the DataDog API
   class APIService
-    attr_reader :api_key, :application_key
     def initialize(api_key, application_key, silent=true, timeout=nil, endpoint=nil)
       @api_key = api_key
       @application_key = application_key
@@ -117,10 +116,8 @@ module Dogapi
       resp = nil
       connect do |conn|
         begin
-          current_url = url + prepare_params(extra_params)
+          current_url = url + prepare_params(extra_params, with_app_key)
           req = method.new(current_url)
-          req['DD-API-KEY'] = @api_key
-          req['DD-APPLICATION-KEY'] = @application_key if with_app_key
 
           if send_json
             req.content_type = 'application/json'
@@ -135,8 +132,9 @@ module Dogapi
       end
     end
 
-    def prepare_params(extra_params)
-      params = {}
+    def prepare_params(extra_params, with_app_key)
+      params = { api_key: @api_key }
+      params[:application_key] = @application_key if with_app_key
       params = extra_params.merge params unless extra_params.nil?
       qs_params = params.map { |k, v| CGI.escape(k.to_s) + '=' + CGI.escape(v.to_s) }
       qs = '?' + qs_params.join('&')

--- a/lib/dogapi/version.rb
+++ b/lib/dogapi/version.rb
@@ -1,3 +1,3 @@
 module Dogapi
-  VERSION = '1.37.0'
+  VERSION = '1.36.0'
 end

--- a/spec/integration/comment_spec.rb
+++ b/spec/integration/comment_spec.rb
@@ -18,7 +18,9 @@ describe Dogapi::Client do
       stub_request(:put, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(:update_comment, COMMENT_ID, options)).to eq ['200', {}]
 
-      expect(WebMock).to have_requested(:put, url)
+      expect(WebMock).to have_requested(:put, url).with(
+        query: default_query
+      )
     end
   end
 

--- a/spec/integration/common_spec.rb
+++ b/spec/integration/common_spec.rb
@@ -12,7 +12,9 @@ describe Dogapi::APIService do
           stub_request(:get, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
           expect(service.request(Net::HTTP::Get, '/api/v1/awesome', nil, nil, true, true)).to eq(['200', {}])
 
-          expect(WebMock).to have_requested(:get, url)
+          expect(WebMock).to have_requested(:get, url).with(
+            query: default_query
+          )
         end
       end
       context 'and it is down' do
@@ -20,7 +22,9 @@ describe Dogapi::APIService do
           stub_request(:get, /#{url}/).to_timeout
           expect(service.request(Net::HTTP::Get, '/api/v1/awesome', nil, nil, true, true)).to eq([-1, {}])
 
-          expect(WebMock).to have_requested(:get, url)
+          expect(WebMock).to have_requested(:get, url).with(
+            query: default_query
+          )
         end
       end
     end

--- a/spec/integration/event_spec.rb
+++ b/spec/integration/event_spec.rb
@@ -37,6 +37,7 @@ describe Dogapi::Client do
       body = MultiJson.dump(EVENT_OPTIONS)
 
       expect(WebMock).to have_requested(:post, url).with(
+        query: { 'api_key' => api_key },
         body: body
       )
     end
@@ -62,6 +63,7 @@ describe Dogapi::Client do
 
       params = STREAM_PARAMS.merge(start: EVENT_START, end: EVENT_END)
       params.each { |k, v| params[k] = v.join(',') if v.is_a? Array }
+      params.merge! default_query
 
       expect(WebMock).to have_requested(:get, url).with(
         query: params

--- a/spec/integration/metric_spec.rb
+++ b/spec/integration/metric_spec.rb
@@ -48,6 +48,7 @@ describe Dogapi::Client do
       body = MultiJson.dump(body)
 
       expect(WebMock).to have_requested(:post, url).with(
+        query: { 'api_key' => api_key },
         body: body
       )
     end
@@ -63,6 +64,7 @@ describe Dogapi::Client do
       body = MultiJson.dump(EMIT_BODY)
 
       expect(WebMock).to have_requested(:post, url).with(
+        query: { 'api_key' => api_key },
         body: body
       )
     end
@@ -87,6 +89,7 @@ describe Dogapi::Client do
       body = MultiJson.dump(BATCH_BODY)
 
       expect(WebMock).to have_requested(:post, url).with(
+        query: { 'api_key' => api_key },
         body: body
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ module SpecDog
   let(:old_api_url) { "#{DATADOG_HOST}/api" }
   let(:api_v2_url) { "#{DATADOG_HOST}/api/v2" }
 
+  let(:default_query) { { api_key: api_key, application_key: app_key } }
+
   shared_examples 'an api method' do |command, args, request, endpoint, body|
     it 'queries the api' do
       url = api_url + endpoint
@@ -35,6 +37,7 @@ module SpecDog
       body = MultiJson.dump(body) if body
 
       expect(WebMock).to have_requested(request, /#{url}|#{old_url}/).with(
+        query: default_query,
         body: body
       )
     end
@@ -52,6 +55,7 @@ module SpecDog
       body = MultiJson.dump(body ? (body.merge options) : options)
 
       expect(WebMock).to have_requested(request, /#{url}|#{old_url}/).with(
+        query: default_query,
         body: body
       )
     end
@@ -63,7 +67,7 @@ module SpecDog
       stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog.send(command, *args, *params.values)).to eq ['200', {}]
       params.each { |k, v| params[k] = v.join(',') if v.is_a? Array }
-      params = params
+      params = params.merge default_query
 
       expect(WebMock).to have_requested(request, url).with(
         query: params
@@ -79,7 +83,7 @@ module SpecDog
       expect(dog.send(command, *args, opt_params)).to eq ['200', {}]
 
       opt_params.each { |k, v| opt_params[k] = v.join(',') if v.is_a? Array }
-      params = opt_params
+      params = opt_params.merge default_query
 
       expect(WebMock).to have_requested(request, url).with(
         query: params
@@ -97,6 +101,7 @@ module SpecDog
       body = MultiJson.dump(body) if body
 
       expect(WebMock).to have_requested(request, url).with(
+        query: default_query,
         body: body
       )
     end
@@ -112,6 +117,7 @@ module SpecDog
       body = MultiJson.dump(body ? (body.merge options) : options)
 
       expect(WebMock).to have_requested(request, url).with(
+        query: default_query,
         body: body
       )
     end
@@ -123,7 +129,7 @@ module SpecDog
       stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog2.send(command, *args, *params.values)).to eq ['200', {}]
       params.each { |k, v| params[k] = v.join(',') if v.is_a? Array }
-      params = params
+      params = params.merge default_query
 
       expect(WebMock).to have_requested(request, url).with(
         query: params
@@ -138,7 +144,7 @@ module SpecDog
       stub_request(request, /#{url}/).to_return(body: '{}').then.to_raise(StandardError)
       expect(dog2.send(command, *args, opt_params)).to eq ['200', {}]
       opt_params.each { |k, v| opt_params[k] = v.join(',') if v.is_a? Array }
-      params = opt_params
+      params = opt_params.merge default_query
 
       expect(WebMock).to have_requested(request, url).with(
         query: params

--- a/spec/unit/common_spec.rb
+++ b/spec/unit/common_spec.rb
@@ -48,13 +48,6 @@ describe 'Common' do
         expect(conn.port).to eq 443
       end
     end
-
-    it 'respects http headers' do
-      service = Dogapi::APIService.new('api_key', 'app_key', true, nil, 'https://app.example.com')
-
-      expect(service.api_key).to eq 'api_key'
-      expect(service.application_key).to eq 'app_key'
-    end
   end
 end
 


### PR DESCRIPTION
Reverts DataDog/dogapi-rb#183
Still a WIP some endpoints won't allow these to be sent as headers (metrics/event submission)