### PR TITLE
[Integration] Add option to pass config

### DIFF
--- a/lib/dogapi/v1/integration.rb
+++ b/lib/dogapi/v1/integration.rb
@@ -35,7 +35,7 @@ module Dogapi
       # Delete an integration
       #
       # :source_type_name => String: the name of an integration source
-      def delete_integration(source_type_namen, config)
+      def delete_integration(source_type_name, config)
         request(Net::HTTP::Delete, "/api/#{API_VERSION}/integration/#{source_type_name}", nil, config, false)
       end
 

--- a/lib/dogapi/v1/integration.rb
+++ b/lib/dogapi/v1/integration.rb
@@ -35,8 +35,8 @@ module Dogapi
       # Delete an integration
       #
       # :source_type_name => String: the name of an integration source
-      def delete_integration(source_type_name)
-        request(Net::HTTP::Delete, "/api/#{API_VERSION}/integration/#{source_type_name}", nil, nil, false)
+      def delete_integration(source_type_namen, config)
+        request(Net::HTTP::Delete, "/api/#{API_VERSION}/integration/#{source_type_name}", nil, config, false)
       end
 
     end


### PR DESCRIPTION
For most of the DD integrations we need to pass a config body in order to delete the proper integration:

* https://docs.datadoghq.com/api/?lang=bash#delete-an-aws-integration
* https://docs.datadoghq.com/api/?lang=bash#delete-an-azure-integration
* https://docs.datadoghq.com/api/?lang=bash#delete-a-gcp-integration