### PR TITLE
Bcon/make query optional monitor update

### DIFF
--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -17,9 +17,10 @@ module Dogapi
       end
 
       def update_monitor(monitor_id, query, options)
-        body = {
-          'query' => query,
-        }.merge options
+        body = {}.merge options
+        if query != nil
+          body = body.merge({'query' => query})
+        end
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/monitor/#{monitor_id}", nil, body, true)
       end

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -17,9 +17,11 @@ module Dogapi
       end
 
       def update_monitor(monitor_id, query, options)
-          body = {}.merge options
+        body = {}.merge options
         if query != nil
-          body = {'query' => query}.merge body
+          body = {
+            'query' => query
+          }.merge body
           warn '[DEPRECATION] query param is no longer required for update'
         end
 

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -18,7 +18,7 @@ module Dogapi
 
       def update_monitor(monitor_id, query, options)
         body = {}.merge options
-        if !query.nil?
+        unless query.nil?
           body = {
             'query' => query
           }.merge body

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -17,9 +17,10 @@ module Dogapi
       end
 
       def update_monitor(monitor_id, query, options)
-        body = {}.merge options
+          body = {}.merge options
         if query != nil
-          body = body.merge({'query' => query})
+          body = {'query' => query}.merge body
+          warn '[DEPRECATION] query param is no longer required for update'
         end
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/monitor/#{monitor_id}", nil, body, true)

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -16,13 +16,15 @@ module Dogapi
         request(Net::HTTP::Post, "/api/#{API_VERSION}/monitor", nil, body, true)
       end
 
-      def update_monitor(monitor_id, query, options)
+      def update_monitor(monitor_id, query = nil, options = {})
         body = {}.merge options
         unless query.nil?
           body = {
             'query' => query
           }.merge body
         end
+        warn '[DEPRECATION] query param is not required anymore and should be set to nil.'\
+             ' To update the query, set it in the options parameter instead'
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/monitor/#{monitor_id}", nil, body, true)
       end

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -22,7 +22,6 @@ module Dogapi
           body = {
             'query' => query
           }.merge body
-          warn '[DEPRECATION] query param is no longer required for update'
         end
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/monitor/#{monitor_id}", nil, body, true)

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -18,7 +18,7 @@ module Dogapi
 
       def update_monitor(monitor_id, query, options)
         body = {}.merge options
-        if query != nil
+        if !query.nil?
           body = {
             'query' => query
           }.merge body

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -22,9 +22,9 @@ module Dogapi
           body = {
             'query' => query
           }.merge body
-        end
-        warn '[DEPRECATION] query param is not required anymore and should be set to nil.'\
+          warn '[DEPRECATION] query param is not required anymore and should be set to nil.'\
              ' To update the query, set it in the options parameter instead'
+        end
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/monitor/#{monitor_id}", nil, body, true)
       end

--- a/lib/dogapi/version.rb
+++ b/lib/dogapi/version.rb
@@ -1,3 +1,3 @@
 module Dogapi
-  VERSION = '1.36.1'
+  VERSION = '1.37.0'
 end

--- a/lib/dogapi/version.rb
+++ b/lib/dogapi/version.rb
@@ -1,3 +1,3 @@
 module Dogapi
-  VERSION = '1.36.0'
+  VERSION = '1.36.1'
 end


### PR DESCRIPTION
Similar to https://github.com/DataDog/datadogpy/pull/447

Made query an optional param.  Tests pass locally, but happy to add some new testing if appropriate.  