### PR TITLE
Fix `cancel_downtime_by_scope` method by setting `send_json` to `true`.

### DIFF
--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -140,7 +140,7 @@ module Dogapi
       end
 
       def cancel_downtime_by_scope(scope)
-        request(Net::HTTP::Post, "/api/#{API_VERSION}/downtime/cancel/by_scope", nil, { 'scope' => scope }, false)
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/downtime/cancel/by_scope", nil, { 'scope' => scope }, true)
       end
 
       def get_all_downtimes(options = {})

--- a/lib/dogapi/version.rb
+++ b/lib/dogapi/version.rb
@@ -1,3 +1,3 @@
 module Dogapi
-  VERSION = '1.37.1'
+  VERSION = '1.37.2'
 end

--- a/spec/integration/monitor_spec.rb
+++ b/spec/integration/monitor_spec.rb
@@ -116,7 +116,7 @@ describe Dogapi::Client do
   describe '#cancel_downtime_by_scope' do
     it_behaves_like 'an api method',
                     :cancel_downtime_by_scope, [DOWNTIME_SCOPE],
-                    :post, '/downtime/cancel/by_scope'
+                    :post, '/downtime/cancel/by_scope', 'scope' => DOWNTIME_SCOPE
   end
 
   describe '#get_all_downtimes' do


### PR DESCRIPTION
We currently don't send the `{ 'scope' => scope }` JSON options, because we had the `set_json` parameter for the `request` function set to `false`. This PR fixes the `cancel_downtime_by_scope` method to send the JSON in the request.

**Current functionality:**
```
dog.cancel_downtime_by_scope("github:armcburney")
=> ["400", {"errors"=>["Expected scope"]}]
```