### PR TITLE
[MA-670] Add `options` to the `get_downtime` endpoint.

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -597,8 +597,8 @@ module Dogapi
       @monitor_svc.update_downtime(downtime_id, options)
     end
 
-    def get_downtime(downtime_id)
-      @monitor_svc.get_downtime(downtime_id)
+    def get_downtime(downtime_id, options = {})
+      @monitor_svc.get_downtime(downtime_id, options)
     end
 
     def cancel_downtime(downtime_id)

--- a/lib/dogapi/v1/monitor.rb
+++ b/lib/dogapi/v1/monitor.rb
@@ -131,8 +131,8 @@ module Dogapi
         request(Net::HTTP::Put, "/api/#{API_VERSION}/downtime/#{downtime_id}", nil, options, true)
       end
 
-      def get_downtime(downtime_id)
-        request(Net::HTTP::Get, "/api/#{API_VERSION}/downtime/#{downtime_id}", nil, nil, false)
+      def get_downtime(downtime_id, options = {})
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/downtime/#{downtime_id}", options, nil, false)
       end
 
       def cancel_downtime(downtime_id)


### PR DESCRIPTION
Allow us to send parameters to the `get_downtime` endpoint.

___

@DataDog/monitor-app 