### PR TITLE
Add 1.9 to CI

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -43,5 +43,7 @@ jobs:
   pool:
     vmImage: "Ubuntu-16.04"
   steps:
-    - script: docker run -v $(Agent.BuildDirectory)/s:/cloned_repo corgibytes/ruby-1.9.3 bin/bash -c "cd cloned_repo; bundle install --retry=3 --jobs=4; bundle exec rake spec"
+    # Until the `container` AZP resource supports being root in a container https://github.com/microsoft/azure-pipelines-agent/issues/2619 we need this long single line approach
+    # Mount this repo into the container, overwrite the Gemfile with the Ruby 1.9.3 supported depdencies, and run tests
+    - script: docker run -v $(Agent.BuildDirectory)/s:/cloned_repo corgibytes/ruby-1.9.3 bin/bash -c "cd cloned_repo; mv Gemfile_1.9 Gemfile; bundle install --retry=3 --jobs=4; bundle exec rake spec"
       displayName: "Run tests with Ruby 1.9.3"

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -45,8 +45,7 @@ jobs:
   container:
     image: corgibytes/ruby-1.9.3
   steps:
-    - script: mkdir local_gems
-    - script: bundle install --retry=3 --jobs=4 --path=local_gems
+    - script: BUNDLE_IGNORE_CONFIG=true bundle install --retry=3 --jobs=4
       displayName: bundle install
     - script: bundle exec rake spec
       displayName: Run spec via bundle

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -42,10 +42,15 @@ jobs:
 - job: TestRuby19
   pool:
     vmImage: "Ubuntu-16.04"
-  container:
-    image: corgibytes/ruby-1.9.3
+  # container:
+  #   image: corgibytes/ruby-1.9.3
   steps:
-    - script: BUNDLE_IGNORE_CONFIG=true bundle install --retry=3 --jobs=4
-      displayName: bundle install
-    - script: bundle exec rake spec
-      displayName: Run spec via bundle
+    # - script: touch /usr/local/bundle/config
+    # - script: whoami
+    # - script: chown `whoami` /usr/local/bundle
+    # - script: ls -la /usr/local/bundle/
+    # - script: bundle install --retry=3 --jobs=4
+    #   displayName: bundle install
+    # - script: bundle exec rake spec
+    #   displayName: Run spec via bundle
+    - script: docker run -v $(Agent.BuildDirectory)/s:/cloned_repo corgibytes/ruby-1.9.3 bin/bash -c "cd cloned_repo; bundle install --retry=3 --jobs=4; bundle exec rake spec"

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -42,15 +42,6 @@ jobs:
 - job: TestRuby19
   pool:
     vmImage: "Ubuntu-16.04"
-  # container:
-  #   image: corgibytes/ruby-1.9.3
   steps:
-    # - script: touch /usr/local/bundle/config
-    # - script: whoami
-    # - script: chown `whoami` /usr/local/bundle
-    # - script: ls -la /usr/local/bundle/
-    # - script: bundle install --retry=3 --jobs=4
-    #   displayName: bundle install
-    # - script: bundle exec rake spec
-    #   displayName: Run spec via bundle
     - script: docker run -v $(Agent.BuildDirectory)/s:/cloned_repo corgibytes/ruby-1.9.3 bin/bash -c "cd cloned_repo; bundle install --retry=3 --jobs=4; bundle exec rake spec"
+    - displayName: "Run tests with Ruby 1.9.3"

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -44,6 +44,7 @@ jobs:
     vmImage: "Ubuntu-16.04"
   steps:
     # Until the `container` AZP resource supports being root in a container https://github.com/microsoft/azure-pipelines-agent/issues/2619 we need this long single line approach
+    # By default AZP clones the repo into a folder called `s` - https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/pipeline-options-for-git?view=azure-devops#checkout-path
     # Mount this repo into the container, overwrite the Gemfile with the Ruby 1.9.3 supported depdencies, and run tests
     - script: docker run -v $(Agent.BuildDirectory)/s:/cloned_repo corgibytes/ruby-1.9.3 bin/bash -c "cd cloned_repo; mv Gemfile_1.9 Gemfile; bundle install --retry=3 --jobs=4; bundle exec rake spec"
       displayName: "Run tests with Ruby 1.9.3"

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -44,4 +44,4 @@ jobs:
     vmImage: "Ubuntu-16.04"
   steps:
     - script: docker run -v $(Agent.BuildDirectory)/s:/cloned_repo corgibytes/ruby-1.9.3 bin/bash -c "cd cloned_repo; bundle install --retry=3 --jobs=4; bundle exec rake spec"
-    - displayName: "Run tests with Ruby 1.9.3"
+      displayName: "Run tests with Ruby 1.9.3"

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -42,3 +42,13 @@ jobs:
       displayName: 'bundle install'
     - script: bundle exec rake $(TASK)
       displayName: Run $(TASK) via bundle
+- job: TestRuby19
+  pool:
+    vmImage: "Ubuntu-16.04"
+  container:
+    image: corgibytes/ruby-1.9.3
+  steps:
+    - script: bundle install --retry=3 --jobs=4
+      displayName: bundle install
+    - script: bundle exec rake spec
+      displayName: Run spec via bundle

--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -15,9 +15,6 @@ jobs:
     vmImage: "Ubuntu-16.04"
   strategy:
     matrix:
-      Rb23:
-        RUBY_VERSION: '2.3.7'
-        TASK: spec
       Rb24:
         RUBY_VERSION: '2.4.6'
         TASK: spec
@@ -48,7 +45,8 @@ jobs:
   container:
     image: corgibytes/ruby-1.9.3
   steps:
-    - script: bundle install --retry=3 --jobs=4
+    - script: mkdir local_gems
+    - script: bundle install --retry=3 --jobs=4 --path=local_gems
       displayName: bundle install
     - script: bundle exec rake spec
       displayName: Run spec via bundle

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :test do
   gem 'rubocop', "~> 0.41.0"
   gem 'rake', '>= 2.4.2'
   gem 'rspec'
-  gem 'simplecov', "~> 0.11.2"
+  gem 'simplecov', "~> 0.12.0"
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rubocop', "~> 0.49.0"
+  gem 'rubocop', "~> 0.41.0"
   gem 'rake', '>= 2.4.2'
   gem 'rspec'
   gem 'simplecov'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :test do
   gem 'rubocop', "~> 0.41.0"
   gem 'rake', '>= 2.4.2'
   gem 'rspec'
-  gem 'simplecov'
+  gem 'simplecov', "~> 0.9.1"
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :test do
   gem 'rubocop', "~> 0.41.0"
   gem 'rake', '>= 2.4.2'
   gem 'rspec'
-  gem 'simplecov', "~> 0.12.0"
+  gem 'simplecov', "~> 0.11.2"
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :test do
   gem 'rubocop', "~> 0.41.0"
   gem 'rake', '>= 2.4.2'
   gem 'rspec'
-  gem 'simplecov', "~> 0.9.1"
+  gem 'simplecov', "~> 0.13.0"
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :test do
   gem 'rubocop', "~> 0.41.0"
   gem 'rake', '>= 2.4.2'
   gem 'rspec'
-  gem 'simplecov', "~> 0.13.0"
+  gem 'simplecov', "~> 0.10.0"
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :test do
   gem 'rubocop', "~> 0.41.0"
   gem 'rake', '>= 2.4.2'
   gem 'rspec'
-  gem 'simplecov', "~> 0.10.0"
+  gem 'simplecov', "~> 0.11.2"
   gem 'webmock'
 end

--- a/Gemfile_1.9
+++ b/Gemfile_1.9
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'rubocop', "~> 0.49.0"
-  gem 'rake'
+  gem 'rubocop', "~> 0.41.0"
+  gem 'rake', '>= 2.4.2'
   gem 'rspec'
-  gem 'simplecov'
+  gem 'simplecov', "~> 0.11.2"
   gem 'webmock'
 end


### PR DESCRIPTION
Add Ruby 1.9.3 to the CI runs
Remove 2.3.7 as its no longer supported by AZP

I attempted to use the nice `containers` feature that AZP has but had to do it in a `docker run` script line due to this issue - https://github.com/microsoft/azure-pipelines-agent/issues/2619

Had to lower the dependency of simplecov (newer versions of the json library don't work with Ruby 1.9.3) and rubocop