### PR TITLE
Unpin ruby bugfix versions in CI and add 2.7

### DIFF
--- a/.azure-pipelines/all.yml
+++ b/.azure-pipelines/all.yml
@@ -16,16 +16,19 @@ jobs:
   strategy:
     matrix:
       Rb24:
-        RUBY_VERSION: '2.4.6'
+        RUBY_VERSION: '2.4'
         TASK: spec
       Rb25:
-        RUBY_VERSION: '2.5.5'
+        RUBY_VERSION: '2.5'
         TASK: spec
       Rb26:
-        RUBY_VERSION: '2.6.3'
+        RUBY_VERSION: '2.6'
+        TASK: spec
+      Rb27:
+        RUBY_VERSION: '2.7'
         TASK: spec
       Lint:
-        RUBY_VERSION: '2.6.3'
+        RUBY_VERSION: '2.6'
         TASK: rubocop
   steps:
     - task: UseRubyVersion@0


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Updates the versions in our Azure Pipelines CI to stop pinning the bugfix versions of Ruby to use when testing in the CI. Now we just pin the minor. 

This PR also adds the Ruby 2.7 versions. 

The CI stopped working as the underlying Azure agent on ubuntu 16.04 updated the provided Ruby versions - https://github.com/actions/virtual-environments/commit/24552f4534c671b038d75bdf32a88d34dcbe5949#diff-f87405c9dd43f633a04dd078666d61afL254-L264

### Verification Process

CI

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

