### PR TITLE
Check exit code of `hostname -f` for failures

### DIFF
--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -202,10 +202,10 @@ module Dogapi
 
   def Dogapi.find_localhost
     unless @@hostname
-      out, status = Open3.capture2("hostname", "-f", :err=>File::NULL)
+      out, status = Open3.capture2('hostname', '-f', :err => File::NULL)
       @@hostname = out.strip
       # Get status to check if the call was successful
-      raise SystemCallError, 'Could not get hostname with `hostname -f`' unless status.exitstatus == 0
+      raise SystemCallError, 'Could not get hostname with `hostname -f`' unless status.exitstatus.zero?
     end
   rescue SystemCallError
     @@hostname = Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -11,6 +11,7 @@ require 'English'
 require 'rubygems'
 require 'multi_json'
 require 'set'
+require 'open3'
 
 module Dogapi
 
@@ -201,7 +202,8 @@ module Dogapi
 
   def Dogapi.find_localhost
     unless @@hostname
-      @@hostname, status = Open3.capture2("hostname", "-f", :err=>File::NULL)
+      out, status = Open3.capture2("hostname", "-f", :err=>File::NULL)
+      @@hostname = out.strip
       # Get status to check if the call was successful
       raise SystemCallError, 'Could not get hostname with `hostname -f`' unless status.exitstatus == 0
     end

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -202,7 +202,7 @@ module Dogapi
 
   def Dogapi.find_localhost
     unless @@hostname
-      out, status = Open3.capture2('hostname', '-f', :err => File::NULL)
+      out, status = Open3.capture2('hostname', '-f', err: File::NULL)
       @@hostname = out.strip
       # Get status to check if the call was successful
       raise SystemCallError, 'Could not get hostname with `hostname -f`' unless status.exitstatus.zero?

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -200,9 +200,12 @@ module Dogapi
   @@hostname = nil
 
   def Dogapi.find_localhost
-    @@hostname ||= %x[hostname -f].strip
+    unless @@hostname
+      @@hostname, status = Open3.capture2("hostname", "-f", :err=>File::NULL)
+      # Get status to check if the call was successful
+      raise SystemCallError, 'Could not get hostname with `hostname -f`' unless status.exitstatus == 0
+    end
   rescue SystemCallError
-    raise $ERROR_INFO unless $ERROR_INFO.class.name == 'Errno::ENOENT'
     @@hostname = Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
   end
 


### PR DESCRIPTION

### What does this PR do?

fixes  #57 

### Description of the Change

`%x["hostname -f"]` call doesn't necessarily raise a `SystemCallError` (on windows 10 notably) on failure, so additionally check for exit status code.

### Verification Process

manual testing on windows

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

