### PR TITLE
Update README with additional info on options for submitting metrics

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -154,6 +154,13 @@ data point you will need to pass a list of +Time+, +float+ pairs, instead of a s
 
     dog.emit_points('some.metric.name', [[t1, val1], [t2, val2], [t3, val3]], :host => "my_host", :device => "my_device")
 
+If you want to specify the metric type, using the example above you can pass in a symbol key with :type and a value of a metric type such as counter, gauage, etc.
+
+    dog.emit_points('some.metric.name', [[t1, val1], [t2, val2], [t3, val3]], :host => "my_host", :device => "my_device", :type => 'counter' )
+
+If you want to add metric tags, using the example above you can pass in a symbol key with :tags and an array of tags.
+
+    dog.emit_points('some.metric.name', [[t1, val1], [t2, val2], [t3, val3]], :host => "my_host", :device => "my_device", :tags => ['frontend', 'app:webserver'] )
 
 == Get points from a Datadog metric
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -154,7 +154,7 @@ data point you will need to pass a list of +Time+, +float+ pairs, instead of a s
 
     dog.emit_points('some.metric.name', [[t1, val1], [t2, val2], [t3, val3]], :host => "my_host", :device => "my_device")
 
-If you want to specify the metric type, using the example above you can pass in a symbol key with :type and a value of a metric type such as counter, gauage, etc.
+If you want to specify the metric type, using the example above you can pass in a symbol key with :type and a value of a metric type such as counter, gauge or rate. 
 
     dog.emit_points('some.metric.name', [[t1, val1], [t2, val2], [t3, val3]], :host => "my_host", :device => "my_device", :type => 'counter' )
 


### PR DESCRIPTION
### What does this PR do?

This is a proposed resolution to #227 which enhances the README to include additional examples for passing in options such as tags or metric type.

### Description of the Change

This is a small update to the README which includes 2 additional examples for submitting tags or a type with a metric.

### Alternate Designs

None considered

### Possible Drawbacks

The code given in the example will still produce warnings in Ruby 2.7 because of [upcoming changes in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

### Verification Process

Proofread my own documentation change

### Additional Notes

None

### Release Notes

None

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

