### PR TITLE
Allow dashboard creation / updates using Template Variable Presets

### DIFF
--- a/lib/dogapi/v1/dashboard.rb
+++ b/lib/dogapi/v1/dashboard.rb
@@ -28,6 +28,11 @@ module Dogapi
       #                           e.g. '["user1@domain.com", "user2@domain.com"]'
       # :template_variables    => JSON: List of template variables for this dashboard.
       #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]
+      # :template_variable_presets => JSON: List of template variables saved views
+      #                           e.g. {
+      #                                  "name": "my_template_variable_preset",
+      #                                  "template_variables": [{"name": "host", "prefix": "host", "default": "my-host"}]
+      #                                }
       def create_board(title, widgets, layout_type, options)
         # Required arguments
         body = {
@@ -40,6 +45,7 @@ module Dogapi
         body[:is_read_only] = options[:is_read_only] if options[:is_read_only]
         body[:notify_list] = options[:notify_list] if options[:notify_list]
         body[:template_variables] = options[:template_variables] if options[:template_variables]
+        body[:template_variable_presets] = options[:template_variable_presets] if options[:template_variable_presets]
 
         request(Net::HTTP::Post, "/api/#{API_VERSION}/#{RESOURCE_NAME}", nil, body, true)
       end
@@ -60,6 +66,11 @@ module Dogapi
       #                           e.g. '["user1@domain.com", "user2@domain.com"]'
       # :template_variables    => JSON: List of template variables for this dashboard.
       #                           e.g. [{"name": "host", "prefix": "host", "default": "my-host"}]
+      # :template_variable_presets => JSON: List of template variables saved views
+      #                           e.g. {
+      #                                  "name": "my_template_variable_preset",
+      #                                  "template_variables": [{"name": "host", "prefix": "host", "default": "my-host"}]
+      #                                }
       def update_board(dashboard_id, title, widgets, layout_type, options)
         # Required arguments
         body = {
@@ -72,6 +83,7 @@ module Dogapi
         body[:is_read_only] = options[:is_read_only] if options[:is_read_only]
         body[:notify_list] = options[:notify_list] if options[:notify_list]
         body[:template_variables] = options[:template_variables] if options[:template_variables]
+        body[:template_variable_presets] = options[:template_variable_presets] if options[:template_variable_presets]
 
         request(Net::HTTP::Put, "/api/#{API_VERSION}/#{RESOURCE_NAME}/#{dashboard_id}", nil, body, true)
       end

--- a/spec/integration/dashboard_spec.rb
+++ b/spec/integration/dashboard_spec.rb
@@ -26,6 +26,15 @@ describe Dogapi::Client do
     'prefix' => 'host',
     'default' => 'my-host'
   }].freeze
+  TEMPLATE_VARIABLE_PRESETS = [{
+    'name' => 'preset1',
+    'template_variables' => [
+      {
+        'name' => 'host1',
+        'value' => 'my-host'
+      }
+    ]
+  }].freeze
 
   REQUIRED_ARGS = {
     title: TITLE,
@@ -37,7 +46,8 @@ describe Dogapi::Client do
     description: DESCRIPTION,
     is_read_only: IS_READ_ONLY,
     notify_list: NOTIFY_LIST,
-    template_variables: TEMPLATE_VARIABLES
+    template_variables: TEMPLATE_VARIABLES,
+    template_variable_presets: TEMPLATE_VARIABLE_PRESETS
   }
   DASHBOARD_ARGS = REQUIRED_ARGS.values + [OPTIONS]
   DASHBOARD_PAYLOAD = REQUIRED_ARGS.merge(OPTIONS)


### PR DESCRIPTION
### What does this PR do?

Allows creating / updating dashboards using `template variable presets` as per [our documentation](https://docs.datadoghq.com/api/v1/dashboards/).

### Description of the Change

Allows passing `template_variable_presets` in `options` when creating or updating dashboards, along with tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

