### PR TITLE
find_localhost: Try both `hostname` and `hostname -f` before raising

### DIFF
--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -210,7 +210,7 @@ module Dogapi
   @@hostname = nil
 
   def Dogapi.find_localhost
-    @@hostname if @@hostname
+    return @@hostname if @@hostname
     out, status = Open3.capture2('hostname', '-f', err: File::NULL)
     unless status.exitstatus.zero?
       begin

--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -216,8 +216,8 @@ module Dogapi
       begin
         out = Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
       rescue SocketError
-        out, status = Open3.capture2('hostname', '-s', err: File::NULL)
-        raise SystemCallError, 'Both `hostname -f` and `hostname -s` did fail.' unless status.exitstatus.zero?
+        out, status = Open3.capture2('hostname', err: File::NULL)
+        raise SystemCallError, 'Both `hostname` and `hostname -f` failed.' unless status.exitstatus.zero?
       end
     end
     @@hostname = out.strip


### PR DESCRIPTION
### What does this PR do?

Potential fix for https://github.com/DataDog/chef-handler-datadog/issues/126

Since #219 we raise if we can't resolve the hostname. Before that (I believe) we returned an empty string, The previous behaviour is not what we want, but raising an exception now makes the problem more obvious. It seems that `hostname -f` might fail but `hostname -s` still succeed, so this PR changes the code to try both before raising.

