### PR TITLE
Add get_all_service_level_objectives to list all SLOs

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -693,6 +693,10 @@ module Dogapi
       @service_level_objective_svc.get_service_level_objective(slo_id)
     end
 
+    def get_all_service_level_objectives
+      @service_level_objective_svc.get_all_service_level_objectives
+    end
+
     def get_service_level_objective_history(slo_id, from_ts, to_ts)
       @service_level_objective_svc.get_service_level_objective_history(slo_id, from_ts, to_ts)
     end

--- a/lib/dogapi/v1/service_level_objective.rb
+++ b/lib/dogapi/v1/service_level_objective.rb
@@ -61,6 +61,10 @@ module Dogapi
         request(Net::HTTP::Get, "/api/#{API_VERSION}/slo/#{slo_id}", nil, nil, false)
       end
 
+      def get_all_service_level_objectives
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/slo", {}, nil, false)
+      end
+
       def search_service_level_objective(slo_ids, query, offset, limit)
         params = {}
         params[:offset] = offset unless offset.nil?

--- a/spec/integration/service_level_objective_spec.rb
+++ b/spec/integration/service_level_objective_spec.rb
@@ -29,6 +29,12 @@ describe Dogapi::Client do
                     :put, "/slo/#{SLO_ID}", 'type' => SLO_TYPE, 'name' => SLO_NAME
   end
 
+  describe '#get_all_service_level_objectives' do
+    it_behaves_like 'an api method',
+                    :get_all_service_level_objectives, [],
+                    :get, '/slo'
+  end
+
   describe '#get_service_level_objective' do
     it_behaves_like 'an api method',
                     :get_service_level_objective, [SLO_ID],


### PR DESCRIPTION
### What does this PR do?

This PR adds the ability to list all the Service Level Objectives on one's account.

I wasn't aware of any parameters to filter, but those could be added here as well if you like.

Closes https://github.com/DataDog/dogapi-rb/issues/248.

Co-authored by @antonio.

### Description of the Change

This simply follows convention of the gem as best as I can, adding a `get_all_service_level_objectives` method which hits `/api/v1/slo` and returns the results as normal.

### Alternate Designs

I used `get_all_...` instead of `list_...` here to follow convention, though my instinct was to use `list_...`.

Calling `search_service_level_objective(nil, nil, nil, nil)` is not very desirable, though I now see that it's a possible workaround.

### Possible Drawbacks

This somewhat duplicates `search_service_level_objective`, but without required parameters.

It does not account for pagination with `limit` and `offset`.

### Verification Process

We're running this exact monkey-patch in our code at the moment, so I know it works as expected.

### Additional Notes

Thank you for your great work on Service Level Objectives!

### Release Notes

Add get_all_service_level_objectives to list all SLOs

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

