### PR TITLE
[MA-1712] Add SLO Correction methods to ruby client.

### DIFF
--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -108,6 +108,8 @@ module Dogapi
       @gcp_integration_svc = Dogapi::V1::GcpIntegrationService.new(@api_key, @application_key, silent, timeout, @datadog_host, skip_ssl_validation)
       @service_level_objective_svc = Dogapi::V1::ServiceLevelObjectiveService.new(@api_key, @application_key, silent,
                                                                                   timeout, @datadog_host, skip_ssl_validation)
+      @slo_correction_svc = Dogapi::V1::ServiceLevelObjectiveService.new(@api_key, @application_key, silent,
+                                                                                  timeout, @datadog_host, skip_ssl_validation)
 
       # Support for Dashboard List API v2.
       @v2 = Dogapi::ClientV2.new(@api_key, @application_key, true, true, @datadog_host, skip_ssl_validation)
@@ -715,6 +717,30 @@ module Dogapi
 
     def delete_timeframes_service_level_objective(ops)
       @service_level_objective_svc.delete_timeframes_service_level_objective(ops)
+    end
+
+    #
+    # SLO CORRECTIONS
+    #
+
+    def create_slo_correction(slo_id, timezone, category, options = {})
+      @slo_correction_svc.create_slo_correction(slo_id, timezone, category, options)
+    end
+
+    def update_slo_correction(slo_correction_id, options = {})
+      @slo_correction_svc.update_slo_correction(slo_correction_id, options)
+    end
+
+    def get_slo_correction(slo_correction_id)
+      @slo_correction_svc.get_slo_correction(slo_correction_id)
+    end
+
+    def get_all_slo_corrections
+      @slo_correction_svc.get_all_slo_corrections
+    end
+
+    def delete_slo_correction(slo_correction_id)
+      @slo_correction_svc.delete_slo_correction(slo_correction_id)
     end
 
     #

--- a/lib/dogapi/facade.rb
+++ b/lib/dogapi/facade.rb
@@ -108,7 +108,7 @@ module Dogapi
       @gcp_integration_svc = Dogapi::V1::GcpIntegrationService.new(@api_key, @application_key, silent, timeout, @datadog_host, skip_ssl_validation)
       @service_level_objective_svc = Dogapi::V1::ServiceLevelObjectiveService.new(@api_key, @application_key, silent,
                                                                                   timeout, @datadog_host, skip_ssl_validation)
-      @slo_correction_svc = Dogapi::V1::ServiceLevelObjectiveService.new(@api_key, @application_key, silent,
+      @slo_correction_svc = Dogapi::V1::SLOCorrectionService.new(@api_key, @application_key, silent,
                                                                                   timeout, @datadog_host, skip_ssl_validation)
 
       # Support for Dashboard List API v2.

--- a/lib/dogapi/v1/service_level_objective.rb
+++ b/lib/dogapi/v1/service_level_objective.rb
@@ -5,7 +5,6 @@ module Dogapi
 
     # Implements Service Level Objectives endpoints
     class ServiceLevelObjectiveService < Dogapi::APIService
-
       API_VERSION = 'v1'
 
       def create_service_level_objective(type, slo_name, thresholds, options = {})

--- a/lib/dogapi/v1/slo_correction.rb
+++ b/lib/dogapi/v1/slo_correction.rb
@@ -11,30 +11,6 @@ module Dogapi
         request(Net::HTTP::Get, "/api/#{API_VERSION}/slo/#{slo_correction_id}", nil, nil, false)
       end
 
-      # Get an SLO correction object for a given SLO correction id.
-      #
-      # URL:
-      #     GET /api/v1/slo/correction/{slo_correction_id}
-      #
-      # Response:
-      #     {
-      #         "data": {
-      #             "type": "correction",
-      #             "id": "<public_id>",
-      #             "attributes": {
-      #                 "slo_id": <slo_id>,
-      #                 "creator": {
-      #                     "data": {
-      #                         "type": "users",
-      #                         "id": "<uuid>",
-      #                         "attributes": {
-      #                             "uuid": "<uuid>"
-      #                         }
-      #                     }
-      #                 }
-      #             }
-      #         }
-      #     }
       def get_slo_correction(slo_correction_id)
         request(Net::HTTP::Get, "/api/#{API_VERSION}/slo/correction/#{slo_correction_id}", nil, nil, false)
       end

--- a/lib/dogapi/v1/slo_correction.rb
+++ b/lib/dogapi/v1/slo_correction.rb
@@ -1,0 +1,73 @@
+require 'dogapi'
+
+module Dogapi
+  class V1 # for namespacing
+
+    # Implements Service Level Objectives correction endpoints.
+    class SLOCorrectionService < Dogapi::APIService
+      API_VERSION = 'v1'
+
+      def get_all_slo_corrections
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/slo/#{slo_correction_id}", nil, nil, false)
+      end
+
+      # Get an SLO correction object for a given SLO correction id.
+      #
+      # URL:
+      #     GET /api/v1/slo/correction/{slo_correction_id}
+      #
+      # Response:
+      #     {
+      #         "data": {
+      #             "type": "correction",
+      #             "id": "<public_id>",
+      #             "attributes": {
+      #                 "slo_id": <slo_id>,
+      #                 "creator": {
+      #                     "data": {
+      #                         "type": "users",
+      #                         "id": "<uuid>",
+      #                         "attributes": {
+      #                             "uuid": "<uuid>"
+      #                         }
+      #                     }
+      #                 }
+      #             }
+      #         }
+      #     }
+      def get_slo_correction(slo_correction_id)
+        request(Net::HTTP::Get, "/api/#{API_VERSION}/slo/correction/#{slo_correction_id}", nil, nil, false)
+      end
+
+      def create_slo_correction(slo_id, timezone, category, options = {})
+        body = {
+          slo_id: slo_id,
+          timezone: timezone,
+          category: category
+        }
+
+        symbolized_options = Dogapi.symbolized_access(options)
+        [:description, :start_dt, :end_dt, :creator_uuid].each do |a|
+          body[a] = symbolized_options[a] if symbolized_options[a]
+        end
+
+        request(Net::HTTP::Post, "/api/#{API_VERSION}/slo/correction", nil, body, true)
+      end
+
+      def update_slo_correction(slo_correction_id, options = {})
+        body = {}
+
+        symbolized_options = Dogapi.symbolized_access(options)
+        [:description, :start_dt, :end_dt, :category, :timezone, :creator_uuid].each do |a|
+          body[a] = symbolized_options[a] if symbolized_options[a]
+        end
+
+        request(Net::HTTP::Put, "/api/#{API_VERSION}/slo/#{slo_correction_id}", nil, body, true)
+      end
+
+      def delete_slo_correction(slo_correction_id)
+        request(Net::HTTP::Delete, "/api/#{API_VERSION}/slo/#{slo_correction_id}", nil, nil, false)
+      end
+    end
+  end
+end

--- a/spec/integration/slo_correction_spec.rb
+++ b/spec/integration/slo_correction_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../spec_helper'
+
+describe Dogapi::Client do
+  SLO_ID = '42424242424242424242424242424242'.freeze
+  SLO_CORRECTION_ID = '12121212121212121212121212121212'.freeze
+  TIMEZONE = 'UTC'.freeze
+  CATEGORY = 'Deployment'.freeze
+  DESCRIPTION = 'Planned maintenance.'.freeze
+  UPDATED_DESCRIPTION = 'Weekly deployment.'.freeze
+  START_DT = 1604966400
+  END_DT = 1605133742
+
+  describe '#create_slo_correction' do
+    it_behaves_like 'an api method',
+                    :create_slo_correction, [SLO_ID, TIMEZONE, CATEGORY, {
+                      description: DESCRIPTION,
+                      start_dt: START_DT,
+                      end_dt: END_DT
+                    }],
+                    :post, '/slo/correction', 'slo_id' => SLO_ID, 'timezone' => TIMEZONE, 'category' => CATEGORY,
+                                   'description' => SLO_DESCRIPTION, 'start_dt': START_DT, 'end_dt': END_DT
+  end
+
+  describe '#update_slo_correction' do
+    it_behaves_like 'an api method',
+                    :update_slo_correction, [SLO_CORRECTION_ID, { description: UPDATED_DESCRIPTION }],
+                    :put, "/slo/correction/#{SLO_CORRECTION_ID}", 'description' => UPDATED_DESCRIPTION
+  end
+
+  describe '#get_all_slo_corrections' do
+    it_behaves_like 'an api method',
+                    :get_all_slo_corrections, nil,
+                    :get, "/slo/correction"
+  end
+
+  describe '#get_slo_correction' do
+    it_behaves_like 'an api method',
+                    :get_slo_correction, [SLO_CORRECTION_ID],
+                    :get, "/slo/correction/#{SLO_CORRECTION_ID}"
+  end
+
+  describe '#delete_slo_correction' do
+    it_behaves_like 'an api method',
+                    :delete_slo_correction, [SLO_CORRECTION_ID],
+                    :delete, "/slo/correction/#{SLO_CORRECTION_ID}"
+  end
+end


### PR DESCRIPTION
### What does this PR do?
[MA-1712] Add SLO Correction methods to ruby client.

### Description of the Change
Adds SLO Correction methods wrapping Datadog API calls.

### Alternate Designs
N/A

### Possible Drawbacks
N/A

### Verification Process
Unit tests.

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.



[MA-1712]: https://datadoghq.atlassian.net/browse/MA-1712