### PR TITLE
Don't shell out to get the hostname

### DIFF
--- a/lib/dogapi/common.rb
+++ b/lib/dogapi/common.rb
@@ -215,16 +215,7 @@ module Dogapi
 
   def Dogapi.find_localhost
     return @@hostname if @@hostname
-    out, status = Open3.capture2('hostname', '-f', err: File::NULL)
-    unless status.exitstatus.zero?
-      begin
-        out = Addrinfo.getaddrinfo(Socket.gethostname, nil, nil, nil, nil, Socket::AI_CANONNAME).first.canonname
-      rescue SocketError
-        out, status = Open3.capture2('hostname', err: File::NULL)
-        raise SystemCallError, 'Both `hostname` and `hostname -f` failed.' unless status.exitstatus.zero?
-      end
-    end
-    @@hostname = out.strip
+    @@hostname = Socket.gethostname
   end
 
   def Dogapi.find_proxy


### PR DESCRIPTION
I've encountered issues where the JVM cannot allocate memory in order to shell out, causing the puppet report integration to fail when trying to run hostname. Considering the socket library is already being loaded, switching the shell out to use socket.gethostname should make this code more reliable with less overhead.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

