### PR TITLE
Document how auto-host generation can increase custom metric counts

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,11 @@ to take advantage of automatic tagging with the host's tags.
 If you want to attach events and points to a specific device
 on a host, simply specify the device when calling emit functions.
 
+Note that auto-host detection can create an excessive number of custom metrics.
+For example, in a Kubernetes CronJob the pod's hostname can be unique
+everytime it runs.  To prevent the creation of excessive number of custom metrics,
+be sure that the "host" is set appropriately.
+
 == Configure the Datadog API Url
 
 


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

This PR documents behavior of the dogapi library that can unexpectedly inflate billing.

### Description of the Change

Adds documentation of how the host field is automatically set, and how that behavior can cause the creation of an excessive number of custom metrics.

### Alternate Designs

One could also change the behavior of dogapi so that host detection was an opt-in rather than an auto-behavior.  However that might break other customers installations.

### Possible Drawbacks

The documentation may be less readable.  This is worth a review to make sure that it appropriately matches the voice and interests of datadog.

### Verification Process

It's a doc update

### Additional Notes

This issue can potentially cost customers a significant amount of money, leading to a lack of trust in the library. 

### Release Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

