### PR TITLE
docs: update datadog_checks_dev installation guide

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ Install [bundler](https://bundler.io/) and setup your RubyGems credentials:
 ---
 :rubygems_api_key: $RUBYGEMS_APIKEY
 ```
-1. Install [datadog_checks_dev](https://datadog-checks-base.readthedocs.io/en/latest/datadog_checks_dev.cli.html#installation) using Python 3.
+1. Install [datadog_checks_dev](https://datadoghq.dev/integrations-core/setup/#ddev) using Python 3.
 
 ### Update Changelog
 #### Commands


### PR DESCRIPTION
### What does this PR do?

- Updates release documentation to include latest link

### Description of the Change

The link provided for installation datadog_checks_dev is now outdated and should instead reference the latest documentation.
